### PR TITLE
Add ADR for reusing exising architecture decisions

### DIFF
--- a/adr/00002-reuse-existing-architecture.md
+++ b/adr/00002-reuse-existing-architecture.md
@@ -1,0 +1,29 @@
+# 2. Reuse existing architecture
+
+Date: 2023-06-13
+
+## Status
+
+Accepted
+
+## Context
+
+Check the Children's Barred List is a monolithic Rails application and should
+use a similar architecture to other monoliths, like
+[Find a lost TRN](https://github.com/DFE-Digital/find-a-lost-trn).
+
+## Decision
+
+We adopt the following ADRs wholesale from Find a Lost TRN, and agree to follow
+their decisions:
+
+- [3. Use a Ruby on Rails monolith](https://github.com/DFE-Digital/find-a-lost-trn/blob/main/adr/00003-use-rails.md)
+- [4. Use Postgres](https://github.com/DFE-Digital/find-a-lost-trn/blob/main/adr/00004-use-postgres-state.md)
+- [5. Use automated tooling to check for security vulnerabilities](https://github.com/DFE-Digital/find-a-lost-trn/blob/main/adr/00005-use-gemsurance-and-.md)
+
+## Consequences
+
+- We don't have to justify the same decisions
+- We can still make adjustments by creating new ADRs down the line
+- Knowledge transfer between teams is simpler
+- Sharing code and modules is simpler


### PR DESCRIPTION
### Context

We want to reuse the existing architecture from other Rails monolith apps.

### Changes proposed in this pull request

Add an ADR stating which architectural decisions we're using from [Find a lost TRN](https://github.com/DFE-Digital/find-a-lost-trn)

### Guidance to review

### Link to Trello card

https://trello.com/c/cgvG8TNl/59-adr-for-initial-architecture

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
