### PR TITLE
Fix `log-level` option name

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/prepare-app-env
 
       - name: Run Prettier
-        run: yarn prettier --check --ignore-unknown --loglevel warn '**/*'
+        run: yarn prettier --check --ignore-unknown --log-level warn '**/*'
 
   rubocop:
     name: Rubocop


### PR DESCRIPTION
### Context

This comes from an issue blocking upgrades to the Prettier gem https://github.com/DFE-Digital/check-childrens-barred-list/pull/30

Prettier can accept a `log-level` option, our github workflow specifies this as `loglevel` without the hyphen.

See:
https://github.com/DFE-Digital/check-childrens-barred-list/actions/runs/5473315846/jobs/9966625307?pr=30#step:4:6

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Use the correctly formatted option name `log-level`.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
