### PR TITLE
[56] Add Statuscake monitoring

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -59,3 +59,26 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
   ]
 }
+
+provider "registry.terraform.io/statuscakedev/statuscake" {
+  version     = "2.1.0"
+  constraints = ">= 2.1.0, 2.1.0"
+  hashes = [
+    "h1:GI/6fNXTYwAcpvo4iES2VbrLJaJg8Lp4TdiQBxyhgTo=",
+    "zh:00cd46ce1502f0df61eb1f1aa6cac07399f20e48c89033dd53314b733762252d",
+    "zh:0fddb98d450ae9ad8daa25b1fec5c1e8c6c6487560d52da57b0e71e2531025e9",
+    "zh:1132ba7edd59a6514a02edb1efac2ca93a79a1831d4cd4d2923330b750aebe2d",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:20c8c16eb2fa16604fbbc0b828f2f74a92a47336e77f7f8cd89cc8f9754cebad",
+    "zh:20d0471e43f3817f52932fec2a7a8f58cdec79c20ac3d6766024516a237cb9cd",
+    "zh:36ba9b954c6316ae71d727cb11daf0aa5274bfd845882a22eb12ebbfb1503d14",
+    "zh:59827eae7136112ea9a45f83fc6bc2807e0980472d27a9faef5ffc329a09c42e",
+    "zh:8095d102d4d9899017cb5a518e3f4e76f6ea635e6181889b0d2e26ae0c35a847",
+    "zh:89c45f1f416f30dd95812f322dd13137612a7a57382b446ed2f6c4593e6c8156",
+    "zh:89f69ab96ae0a70c8270deb40e5a4d84e6c4cfc20c7f1671339c45ef8a5daad2",
+    "zh:a6bda1fc94bb7b47adb81cde18057037ab0febb3f0272c76addfec35726b72f1",
+    "zh:b04dedbe459ba39fe82b4a5d71d23f80ac2b11bb5686fdbd92a9118e128bee8d",
+    "zh:c31851ebcb6fdf745c31900a319fc5e0422019e49ef03406e61f3bcaa61ffc05",
+    "zh:e08c785ec8703a60362b9f4e66e3b6b1b8b0c8867c0ac87590bab3bd5ab5b3f1",
+  ]
+}

--- a/terraform/aks/monitoring.tf
+++ b/terraform/aks/monitoring.tf
@@ -1,0 +1,10 @@
+module "statuscake" {
+  count = var.enable_monitoring ? 1 : 0
+
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//monitoring/statuscake?ref=testing"
+
+  uptime_urls = compact([module.web_application.probe_url, var.external_url])
+  ssl_urls    = compact([var.external_url])
+
+  contact_groups = [249142]
+}

--- a/terraform/aks/providers.tf
+++ b/terraform/aks/providers.tf
@@ -16,5 +16,5 @@ provider "kubernetes" {
 }
 
 provider "statuscake" {
-  api_token = try(local.infra_secrets.STATUSCAKE_API_TOKEN, null)
+  api_token = local.infra_secrets.STATUSCAKE_API_TOKEN
 }

--- a/terraform/aks/providers.tf
+++ b/terraform/aks/providers.tf
@@ -14,3 +14,7 @@ provider "kubernetes" {
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
 }
+
+provider "statuscake" {
+  api_token = try(local.infra_secrets.STATUSCAKE_API_TOKEN, null)
+}

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -6,9 +6,15 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "3.57.0"
     }
+
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "2.20.0"
+    }
+
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "2.1.0"
     }
   }
 

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -1,38 +1,129 @@
-variable "cluster" {}
-variable "namespace" {}
-variable "environment" {}
-variable "azure_credentials_json" { default = null }
-variable "azure_resource_prefix" {}
-variable "config_short" {}
-variable "service_short" {}
-variable "deploy_azure_backing_services" { default = true }
-variable "rg_name" {}
-variable "enable_postgres_ssl" { default = true }
+variable "app_config_file" {
+  type    = string
+  default = "config/app_config.yml"
+}
+
+variable "app_docker_image" {
+  type = string
+}
+
+variable "app_name" {
+  type    = string
+  default = null
+}
+
+variable "app_name_suffix" {
+  type    = string
+  default = null
+}
+
+variable "azure_credentials_json" {
+  type    = string
+  default = null
+}
+
+variable "azure_maintenance_window" {
+  type    = map
+  default = null
+}
+
+variable "azure_resource_prefix" {
+  type = string
+}
 
 variable "azure_sp_credentials_json" {
   type    = string
   default = null
 }
 
-variable "key_vault_name" {}
-variable "key_vault_infra_secret_name" {}
-variable "key_vault_app_secret_name" {}
-variable "app_name_suffix" { default = null }
-variable "postgres_version" { default = 14 }
-variable "app_name" { default = null }
-variable "app_docker_image" {}
-variable "enable_monitoring" { default = true }
-variable "app_config_file" { default = "config/app_config.yml" }
-variable "azure_maintenance_window" { default = null }
-variable "postgres_flexible_server_sku" { default = "B_Standard_B1ms" }
-variable "postgres_enable_high_availability" { default = false }
-variable "startup_command" {}
-variable "probe_path" { default = null }
-variable "replicas" { default = 1 }
-variable "memory_max" { default = "1Gi" }
+variable "cluster" {
+  type = string
+}
+
+variable "config_short" {
+  type = string
+}
+
+variable "deploy_azure_backing_services" {
+  type    = bool
+  default = true
+}
+
+variable "enable_monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "enable_postgres_ssl" {
+  type    = bool
+  default = true
+}
+
+variable "environment" {
+  type = string
+}
+
 variable "gov_uk_host_names" {
   default = []
   type    = list(any)
+}
+
+variable "key_vault_app_secret_name" {
+  type = string
+}
+
+variable "key_vault_infra_secret_name" {
+  type = string
+}
+
+variable "key_vault_name" {
+  type = string
+}
+
+variable "memory_max" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "postgres_enable_high_availability" {
+  type    = string
+  default = false
+}
+
+variable "postgres_flexible_server_sku" {
+  type    = string
+  default = "B_Standard_B1ms"
+}
+
+variable "postgres_version" {
+  type    = number
+  default = 14
+}
+
+variable "probe_path" {
+  type    = string
+  default = null
+}
+
+variable "replicas" {
+  type    = number
+  default = 1
+}
+
+variable "rg_name" {
+  type = string
+}
+
+variable "service_short" {
+  type = string
+}
+
+variable "startup_command" {
+  type = list(string)
 }
 
 locals {
@@ -43,14 +134,13 @@ locals {
 
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 
-  app_name_suffix  = var.app_name == null ? var.environment : var.app_name
-  kv_app_secrets    = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
-  infra_secrets     = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
-  app_config        = yamldecode(file(var.app_config_file))[var.environment]
+  app_name_suffix = var.app_name == null ? var.environment : var.app_name
+  kv_app_secrets  = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
+  infra_secrets   = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
+  app_config      = yamldecode(file(var.app_config_file))[var.environment]
 
   app_env_values = merge(
     local.app_config,
-    #  sslmode not defined in database.yml?
     { DB_SSLMODE = local.postgres_ssl_mode }
   )
 
@@ -59,7 +149,7 @@ locals {
   app_secrets = merge(
     local.kv_app_secrets,
     {
-      DATABASE_URL        = module.postgres.url
+      DATABASE_URL = module.postgres.url
     }
   )
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -63,6 +63,11 @@ variable "environment" {
   type = string
 }
 
+variable "external_url" {
+  type    = string
+  default = null
+}
+
 variable "gov_uk_host_names" {
   default = []
   type    = list(any)


### PR DESCRIPTION
### Context

We want to be alerted if the service goes down. We use statuscake for this on other projects.

### Changes proposed in this pull request

[Add statuscake reporting via terraform](https://github.com/DFE-Digital/check-childrens-barred-list/commit/26eb29bb4f591c6814b35aefd31a8455aea0b726) 

- Add new statuscake module to monitoring.tf, this expects an external_url variable
  and uses the same contact group as other TRA services
- Adds statuscake provider, which requires a STATUSCAKE_API_TOKEN in secrets
- Adds external_url to variables, defaulting to null
 
**In a separate commit (no actual changes):**

[Alphabetise terraform variables file and add types](https://github.com/DFE-Digital/check-childrens-barred-list/commit/050b11b34b3ef9f277a375d8417c237b5eedfdd8) 

### Guidance to review

### Link to Trello card

https://trello.com/c/AQeHLLU8/56-statuscake

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
