### PR TITLE
[85] Healthchecks

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -85,7 +85,7 @@ jobs:
             type=registry,ref=${{env.DOCKER_IMAGE}}:main
             type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
             type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
-          build-args: COMMIT_SHA=${{ github.sha }}
+          build-args: COMMIT_SHA=${{ env.IMAGE_TAG }}
 
       - name: Push ${{ env.DOCKER_IMAGE }} images for review
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,8 @@ RUN apk add --no-cache libpq
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+ARG COMMIT_SHA
+ENV COMMIT_SHA=$COMMIT_SHA
+
 CMD bundle exec rails db:migrate && \
     bundle exec rails server -b 0.0.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem "bootsnap", require: false
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 
+# Provide endpoint for server healthchecks
+gem "okcomputer"
+
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
     nokogiri (1.15.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    okcomputer (1.18.4)
     pagy (6.0.4)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -339,6 +340,7 @@ DEPENDENCIES
   govuk-components
   govuk_design_system_formbuilder
   jsbundling-rails
+  okcomputer
   pg (~> 1.1)
   prettier_print
   propshaft

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,8 @@
+OkComputer.mount_at = "healthcheck"
+
+OkComputer::Registry.register(
+  "version",
+  OkComputer::AppVersionCheck.new(env: "COMMIT_SHA"),
+)
+
+OkComputer.make_optional(%w[version])

--- a/spec/requests/healthchecks_spec.rb
+++ b/spec/requests/healthchecks_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Healthchecks" do
+  describe "/healthcheck" do
+    it "responds successfully when the rails server is up" do
+      get "/healthcheck"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "/healthcheck/database" do
+    it "responds successfully when database is up" do
+      get "/healthcheck/database"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to have a stable probe paths so we can check that the app and database are up and running.

### Changes proposed in this pull request

Install okcomputer gem and configure the following checks:

**/healthcheck**
```
default: PASSED Application is running (0.000s)
```

**/healthcheck/database**
```
database: PASSED Schema version: 0 (0.023s)
```

**/healthcheck/version**
```
version: PASSED Version: c7b627ec257918e6831d1bc2747819883e4880eb (0.000s) (OPTIONAL)
```

**/healthcheck/all**
```
Default Collection
  database: PASSED Schema version: 0 (0.023s)
  default: PASSED Application is running (0.000s)
  version: PASSED Version: c7b627ec257918e6831d1bc2747819883e4880eb (0.000s) (OPTIONAL)
```

You can also retrieve the above as json.

### Guidance to review

Check the above endpoints on the review app.

### Link to Trello card

https://trello.com/c/nXArdNIw/85-add-healthcheck

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
