### PR TITLE
Add basic auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,18 @@
 class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
+
+  before_action :authenticate
+
+  def authenticate
+    valid_credentials = [
+      {
+        username: ENV.fetch("SUPPORT_USERNAME", "support"),
+        password: ENV.fetch("SUPPORT_PASSWORD", "support"),
+      },
+    ]
+
+    authenticate_or_request_with_http_basic do |username, password|
+      valid_credentials.include?({ username:, password: })
+    end
+  end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -2,9 +2,23 @@ require "rails_helper"
 
 RSpec.describe "Pages", type: :request do
   describe "GET /home" do
-    it "returns http success" do
+    it "requires authentication" do
       get "/"
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "with valid basic auth credentials" do
+      let(:credentials) do
+        ActionController::HttpAuthentication::Basic.encode_credentials(
+          ENV.fetch("SUPPORT_USERNAME", "support"),
+          ENV.fetch("SUPPORT_PASSWORD", "support")
+        )
+      end
+
+      it "returns http success" do
+        get "/", env: { "HTTP_AUTHORIZATION" => credentials }
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

We have running `test` and `preproduction` environments but the app is under development and shouldn't be accessible without some sort of authentication.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds basic authentication at the application controller level.
Credentials can be set or amended via the `SUPPORT_USERNAME` and `SUPPORT_PASSWORD` env vars.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
