### PR TITLE
Fix non production deploy job

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -166,5 +166,5 @@ jobs:
         id: deploy
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          docker-image: ${{ needs.build.outputs.docker_image }}
           environment: ${{ matrix.environment }}
+          sha: ${{ needs.build.outputs.IMAGE_TAG }}


### PR DESCRIPTION
### Context

The `deploy_nonprod` workflow uses the wrong variable name and value for the docker image SHA.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Amend the deployment job to use the deploy arg `sha` with the value from `build.outputs.IMAGE_TAG`.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/rjkrM1Xj/75-add-test-and-preproduction-deployment-pipeline

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
