### PR TITLE
Amend govuk hostnames

### DIFF
--- a/terraform/aks/config/preproduction.tfvars.json
+++ b/terraform/aks/config/preproduction.tfvars.json
@@ -17,7 +17,7 @@
   "replicas": 1,
   "memory_max": "1Gi",
   "gov_uk_host_names": [
-    "preproduction.check-childrens-barred-list.education.gov.uk"
+    "preproduction.check-the-childrens-barred-list.education.gov.uk"
   ],
   "azure_enable_backup_storage": false
 }

--- a/terraform/aks/config/test.tfvars.json
+++ b/terraform/aks/config/test.tfvars.json
@@ -16,6 +16,8 @@
   ],
   "replicas": 1,
   "memory_max": "1Gi",
-  "gov_uk_host_names": ["test.check-childrens-barred-list.education.gov.uk"],
+  "gov_uk_host_names": [
+    "test.check-the-childrens-barred-list.education.gov.uk"
+  ],
   "azure_enable_backup_storage": false
 }

--- a/terraform/custom_domains/environment_domains/config/ccbl_preproduction.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_preproduction.tfvars.json
@@ -1,0 +1,15 @@
+{
+  "enable_alerting": false,
+  "hosted_zone": {
+    "check-the-childrens-barred-list.education.gov.uk": {
+      "front_door_name": "s189p01-ccbl-edu-domains-fd",
+      "resource_group_name": "s189p01-ccbldomains-rg",
+      "domains": ["preproduction"],
+      "cached_paths": ["/assets/*"],
+      "environment_short": "pp",
+      "origin_hostname": "check-childrens-barred-list-preproduction.test.teacherservices.cloud",
+      "null_host_header": true,
+      "cnames": {}
+    }
+  }
+}

--- a/terraform/custom_domains/environment_domains/config/ccbl_preproduction_backend.tfvars
+++ b/terraform/custom_domains/environment_domains/config/ccbl_preproduction_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-ccbldomains-rg"
+storage_account_name = "s189p01ccbldomainstf"
+container_name       = "ccbldomains-tf"
+key                  = "ccbldomains_preproduction.tfstate"


### PR DESCRIPTION
### Context

Terraform `govuk_host_names` configurations do not match the domain setup config.

See: https://github.com/DFE-Digital/check-childrens-barred-list/blob/main/terraform/custom_domains/infrastructure/config/ccbl.tfvars.json#L3

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Amends `govuk_host_names` values to use the correct app domain _check-**the**-childrens-barred-list.education.gov.uk_ as per https://github.com/DFE-Digital/check-childrens-barred-list/blob/main/terraform/custom_domains/infrastructure/config/ccbl.tfvars.json#L3

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I've planned and applied this so check that https://test.check-the-childrens-barred-list.education.gov.uk/ works

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/ekjOh0Gp/55-deployment-pipeline
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
