### PR TITLE
Make app logs write to STDOUT

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -33,4 +33,7 @@ module "application_configuration" {
   config_variables      = local.app_env_values
   secret_variables      = local.app_secrets
   secret_yaml_key       = var.key_vault_app_secret_name
+
+  # This sets the RAILS_LOG_TO_STDOUT env var for logs
+  is_rails_application = true
 }


### PR DESCRIPTION
### Context

We want to capture app logs.
For now we rely on Azure log analytics, eventually these will go into Logit.
All that we need to do is ensure the app writes to stdout.

### Changes proposed in this pull request

- Set the `is_rails_application` variable to `true` in `application_configuration` terraform module
- This sets the `RAILS_LOG_TO_STDOUT` env var which ensures logs are captured in Azure log analytics

### Guidance to review

### Link to Trello card

https://trello.com/c/wYe5ZpGa/57-logging

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
