### PR TITLE
Add a configurable database url

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,7 @@ default: &default
 development:
   <<: *default
   database: check_the_childrens_barred_list_development
+  url: <%= ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost:5432') %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,6 +59,7 @@ development:
 test:
   <<: *default
   database: check_the_childrens_barred_list_test
+  url: <%= ENV.fetch('DATABASE_URL', 'postgres://postgres@localhost:5432') %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
### Context

If you do not have your system user configured with the correct permissions for dev/test postgres you'll see the error:

`PG::ConnectionBad: FATAL: role "<user>" does not exist`
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Simplifies connecting to a dev or test db as it can be overridden in an env file if you prefer to use your system username instead of `postgres`.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
