### PR TITLE
[91] Add service open feature flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apk add --update --no-cache tzdata && \
 # postgresql-dev: postgres driver and libraries
 RUN apk add --no-cache build-base yarn postgresql13-dev
 
+# git: required to clone DFE repos
+RUN apk add --no-cache git
+
 # Install gems defined in Gemfile
 COPY .ruby-version Gemfile Gemfile.lock ./
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "okcomputer"
 gem "sentry-rails"
 gem "sentry-ruby"
 
+# Feature switching
+gem "govuk_feature_flags", github: "DFE-Digital/govuk_feature_flags", branch: "main"
+
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/DFE-Digital/govuk_feature_flags.git
+  revision: 0d70b78786bce833d0e1554a645a6170896d7449
+  branch: main
+  specs:
+    govuk_feature_flags (0.1.0)
+      rails (>= 7.0.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -345,6 +353,7 @@ DEPENDENCIES
   debug
   govuk-components
   govuk_design_system_formbuilder
+  govuk_feature_flags!
   jsbundling-rails
   okcomputer
   pg (~> 1.1)

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,0 +1,4 @@
+feature_flags:
+  service_open:
+    author: Steve Laing
+    description: Allow users to access the service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,1 +1,5 @@
-Rails.application.routes.draw { root to: "pages#home" }
+Rails.application.routes.draw do
+  root to: "pages#home"
+
+  mount FeatureFlags::Engine => "/features"
+end

--- a/db/migrate/20230714094421_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230714094421_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,58 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, 
+unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/migrate/20230714094422_create_feature_flags_features.feature_flags.rb
+++ b/db/migrate/20230714094422_create_feature_flags_features.feature_flags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from feature_flags (originally 20221005090626)
+class CreateFeatureFlagsFeatures < ActiveRecord::Migration[7.0]
+  def change
+    create_table :feature_flags_features do |t|
+      t.string :name, null: false
+      t.boolean :active, default: false, null: false
+
+      t.timestamps
+    end
+    add_index :feature_flags_features, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,46 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_14_094422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "feature_flags_features", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "active", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_feature_flags_features_on_name", unique: true
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
### Context

We would like to be open the service using a feature flag controlled from the support interface.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Adds GOVUK feature flag library and migrations
- Adds service open feature flag 

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/55FJbKOF/91-ccbl-add-service-open-feature-flag
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
