### PR TITLE
Add Github `deploy_production` workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -168,3 +168,23 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ matrix.environment }}
           sha: ${{ needs.build.outputs.IMAGE_TAG }}
+
+  deploy_production:
+    name: Deploy to production AKS environment
+    needs: [build, deploy_nonprod]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+    concurrency: deploy_production
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/deploy
+        id: deploy
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          environment: production
+          sha: ${{ needs.build.outputs.IMAGE_TAG }}


### PR DESCRIPTION
### Context

We now have a production environment, we'd like to be able to deploy code to it.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds `deploy_production` Github workflow. This is dependent on `deploy_nonprod` job which deploys to test and preproduction environments.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/ekjOh0Gp/55-deployment-pipeline
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
