### PR TITLE
[111] Date of birth validations

### DIFF
--- a/app/validators/day_month_year_validator.rb
+++ b/app/validators/day_month_year_validator.rb
@@ -13,6 +13,7 @@ class DayMonthYearValidator
 
     record.errors.add(attribute, :invalid_year) if invalid_year?
     record.errors.add(attribute, :future) if date.future?
+    record.errors.add(attribute, :over_100) if over_100?
     record.errors.add(attribute, :under_16) if under_16?
   end
 
@@ -40,6 +41,10 @@ class DayMonthYearValidator
 
   def under_16?
     date >= 16.years.ago
+  end
+
+  def over_100?
+    date <= 100.years.ago
   end
 
   def date

--- a/app/validators/day_month_year_validator.rb
+++ b/app/validators/day_month_year_validator.rb
@@ -4,17 +4,19 @@ class DayMonthYearValidator
   def validate(record, attribute)
     @record = record
 
+    return true unless all_present?
+
     record.errors.add(attribute, :invalid) unless valid?
+    record.errors.add(attribute, :invalid_year) unless year_valid?
   end
 
   private
 
-  def valid?
-    unless @record.day.present? && @record.month.present? &&
-             @record.year.present?
-      return true
-    end
+  def all_present?
+    @record.day.present? && @record.month.present? && @record.year.present?
+  end
 
+  def valid?
     day = @record.day.to_i
     month = @record.month.to_i
     year = @record.year.to_i
@@ -24,5 +26,9 @@ class DayMonthYearValidator
     Date.valid_date?(year, month, day)
   rescue ArgumentError
     false
+  end
+
+  def year_valid?
+    @record.year.length == 4
   end
 end

--- a/app/validators/day_month_year_validator.rb
+++ b/app/validators/day_month_year_validator.rb
@@ -6,8 +6,14 @@ class DayMonthYearValidator
 
     return true unless all_present?
 
-    record.errors.add(attribute, :invalid) unless valid?
-    record.errors.add(attribute, :invalid_year) unless year_valid?
+    unless valid?
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    record.errors.add(attribute, :invalid_year) if invalid_year?
+    record.errors.add(attribute, :future) if date.future?
+    record.errors.add(attribute, :under_16) if under_16?
   end
 
   private
@@ -28,7 +34,15 @@ class DayMonthYearValidator
     false
   end
 
-  def year_valid?
-    @record.year.length == 4
+  def invalid_year?
+    @record.year.length != 4
+  end
+
+  def under_16?
+    date >= 16.years.ago
+  end
+
+  def date
+    @date ||= Date.new(@record.year.to_i, @record.month.to_i, @record.day.to_i)
   end
 end

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -8,7 +8,7 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :last_name, class: "govuk-input--width-20", label: { text: "Last name", size: "s" } %>
-      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: "Date of birth", size: "s" } %>
+      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: "Date of birth", size: "s" }, hint: { text: "For example, 31 3 #{40.years.ago.year}" } %>
 
       <%= f.govuk_submit "Search" %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,8 @@ en:
               blank: Enter a last name
             date_of_birth:
               blank: Enter a date of birth
-              invalid: Enter a valid date of birth
+              invalid: Date of birth must be a real date
+              invalid_year: Year must include 4 numbers
         "support_interface/upload_form":
           attributes:
             file:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
               future: Date of birth must be in the past
               invalid: Date of birth must be a real date
               invalid_year: Year must include 4 numbers
+              over_100: Date of birth cannot be more than 100 years ago
               under_16: Date of birth must be at least 16 years ago
         "support_interface/upload_form":
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,8 +12,10 @@ en:
               blank: Enter a last name
             date_of_birth:
               blank: Enter a date of birth
+              future: Date of birth must be in the past
               invalid: Date of birth must be a real date
               invalid_year: Year must include 4 numbers
+              under_16: Date of birth must be at least 16 years ago
         "support_interface/upload_form":
           attributes:
             file:

--- a/spec/validators/day_month_year_validator_spec.rb
+++ b/spec/validators/day_month_year_validator_spec.rb
@@ -10,12 +10,12 @@ class Validatable
 end
 
 RSpec.describe DayMonthYearValidator do
-  subject(:validatable) { Validatable.new(valid_attributes) }
-
-  let(:valid_attributes) { { day: "15", month: "6", year: "1990" } }
+  subject(:validatable) { Validatable.new(attributes) }
 
   describe "#validate" do
     context "when the date is valid" do
+      let(:attributes) { { day: "15", month: "6", year: "1990" } }
+
       it "passes validation" do
         validatable.valid?
 
@@ -23,40 +23,66 @@ RSpec.describe DayMonthYearValidator do
       end
     end
 
-    context "when the date is invalid" do
-      it "fails validation with invalid dates" do
-        validatable.day = "31"
-        validatable.month = "13"
-        validatable.valid?
+    context "when the day is invalid" do
+      let(:attributes) { { day: "32", month: "6", year: "1990" } }
 
-        expect(validatable.errors[:date_attribute]).to include("is invalid")
-      end
-
-      it "fails validation with negative dates" do
-        validatable.day = -1
-        validatable.month = "2"
+      it "fails validation" do
         validatable.valid?
 
         expect(validatable.errors[:date_attribute]).to include("is invalid")
       end
     end
 
-    context "when missing fields" do
-      it "does not perform validation if day `nil`" do
-        validatable.day = nil
+    context "when the month is invalid" do
+      let(:attributes) { { day: "15", month: "60", year: "1990" } }
 
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute]).to include("is invalid")
+      end
+    end
+    
+    context "when the date is negative" do
+      let(:attributes) { { day: -1, month: "6", year: "1990" } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute]).to include("is invalid")
+      end
+    end
+
+    context "when the year does not have 4 numbers" do
+      let(:attributes) { { day: "15", month: "6", year: "90" } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("invalid_year")
+      end
+    end
+
+    context "when day is missing" do
+      let(:attributes) { { day: nil, month: "6", year: "1990" } }
+
+      it "does not perform validation" do
         expect(validatable).to be_valid
       end
+    end
 
-      it "does not perform validation if month `nil`" do
-        validatable.month = nil
+    context "when month is missing" do
+      let(:attributes) { { day: "15", month: nil, year: "1990" } }
 
+      it "does not perform validation" do
         expect(validatable).to be_valid
       end
+    end
 
-      it "does not perform validation if year `nil`" do
-        validatable.year = nil
+    context "when year is missing" do
+      let(:attributes) { { day: "15", month: "6", year: nil } }
 
+      it "does not perform validation" do
         expect(validatable).to be_valid
       end
     end

--- a/spec/validators/day_month_year_validator_spec.rb
+++ b/spec/validators/day_month_year_validator_spec.rb
@@ -83,6 +83,16 @@ RSpec.describe DayMonthYearValidator do
       end
     end
 
+    context "when the date more than 100 years ago" do
+      let(:attributes) { { day: "15", month: "6", year: 101.years.ago.year.to_s } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("over_100")
+      end
+    end
+
     context "when day is missing" do
       let(:attributes) { { day: nil, month: "6", year: "1990" } }
 

--- a/spec/validators/day_month_year_validator_spec.rb
+++ b/spec/validators/day_month_year_validator_spec.rb
@@ -63,6 +63,26 @@ RSpec.describe DayMonthYearValidator do
       end
     end
 
+    context "when the date is in the future" do
+      let(:attributes) { { day: "15", month: "6", year: 1.year.from_now.year.to_s } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("future")
+      end
+    end
+
+    context "when the date less than 16 years ago" do
+      let(:attributes) { { day: "15", month: "6", year: 15.years.ago.year.to_s } }
+
+      it "fails validation" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("under_16")
+      end
+    end
+
     context "when day is missing" do
       let(:attributes) { { day: nil, month: "6", year: "1990" } }
 


### PR DESCRIPTION
### Context

We want to show different errors for different types of 'invalid' dates of birth.

### Changes proposed in this pull request

Add validations for:
- date in the future
- date under 16
- year must have 4 numbers
- date over 100

Also add hint text.

### Guidance to review

Attempt to search with invalid dates as per the above list and check the error messages.

<img width="694" alt="Screenshot 2023-07-31 at 21 36 56" src="https://github.com/DFE-Digital/check-childrens-barred-list/assets/18436946/97865c55-b24c-443f-9c55-a0b2d565f6cf">

### Link to Trello card

https://trello.com/c/yZysFoSW/111-date-of-birth-validations

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally