### PR TITLE
Improve search by making it whitespace/case/accent insensitive

### DIFF
--- a/app/models/childrens_barred_list_entry.rb
+++ b/app/models/childrens_barred_list_entry.rb
@@ -10,7 +10,7 @@ class ChildrensBarredListEntry < ApplicationRecord
   def self.includes_record?(last_name:, date_of_birth:)
     where(
       "lower(unaccent(last_name)) = ?",
-      ActiveSupport::Inflector.transliterate(last_name.downcase)
+      ActiveSupport::Inflector.transliterate(last_name.strip.downcase)
     ).and(where(date_of_birth:)).any?
   end
 end

--- a/app/models/childrens_barred_list_entry.rb
+++ b/app/models/childrens_barred_list_entry.rb
@@ -8,6 +8,9 @@ class ChildrensBarredListEntry < ApplicationRecord
   validates :date_of_birth, presence: true
 
   def self.includes_record?(last_name:, date_of_birth:)
-    where("lower(last_name) = ?", last_name.downcase).and(where(date_of_birth:)).any?
+    where(
+      "lower(unaccent(last_name)) = ?",
+      ActiveSupport::Inflector.transliterate(last_name.downcase)
+    ).and(where(date_of_birth:)).any?
   end
 end

--- a/app/services/create_childrens_barred_list_entries.rb
+++ b/app/services/create_childrens_barred_list_entries.rb
@@ -32,6 +32,7 @@ class CreateChildrensBarredListEntries
   end
 
   def format_names(names)
+    names.strip!
     names.gsub!(TITLES_REGEX, "")
     names.split(" ").map(&:capitalize).join(" ")
   end

--- a/db/migrate/20230802092514_add_unaccent_extension.rb
+++ b/db/migrate/20230802092514_add_unaccent_extension.rb
@@ -1,0 +1,11 @@
+class AddUnaccentExtension < ActiveRecord::Migration[7.0]
+  UNACCENT_EXTENSION = "unaccent".freeze
+
+  def up
+    enable_extension(UNACCENT_EXTENSION) unless extensions.include?(UNACCENT_EXTENSION)
+  end
+
+  def down
+    disable_extension(UNACCENT_EXTENSION) if extensions.include?(UNACCENT_EXTENSION)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_103819) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_02_092514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/spec/models/childrens_barred_list_entry_spec.rb
+++ b/spec/models/childrens_barred_list_entry_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe ChildrensBarredListEntry, type: :model do
       end
     end
 
+    context "with a whitespace insensitive match on last_name" do
+      it "returns true" do
+        expect(
+          described_class.includes_record?(
+            last_name: " Doe ",
+            date_of_birth: record.date_of_birth,
+          ),
+        ).to be_truthy
+      end
+    end
+
     context "with matching DoB but no matching last_name" do
       it "returns false" do
         expect(

--- a/spec/models/childrens_barred_list_entry_spec.rb
+++ b/spec/models/childrens_barred_list_entry_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe ChildrensBarredListEntry, type: :model do
       end
     end
 
+    context "with an accent-insensitive match on last_name" do
+      it "returns true" do
+        expect(
+          described_class.includes_record?(
+            last_name: "Doé",
+            date_of_birth: record.date_of_birth,
+          ),
+        ).to be_truthy
+      end
+    end
+
     context "with matching DoB but no matching last_name" do
       it "returns false" do
         expect(

--- a/spec/services/create_childrens_barred_list_entries_spec.rb
+++ b/spec/services/create_childrens_barred_list_entries_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe CreateChildrensBarredListEntries do
   let(:csv_data) do
     [
-      ["12567", "SMITH", "DR. JOHN JAMES", "01/02/1990", "AB123456C"].join(","),
-      ["1234568", "jones", "mrs jane jemima", "07/05/1980", "AB123456D"].join(",")
+      ["12567", "SMITH ", "DR. JOHN JAMES ", "01/02/1990", "AB123456C"].join(","),
+      ["1234568", " jones ", " mrs jane jemima", "07/05/1980", "AB123456D"].join(",")
     ].join("\n")
   end
 
@@ -33,6 +33,8 @@ RSpec.describe CreateChildrensBarredListEntries do
   it "formats the names" do
     service.call
     expect(ChildrensBarredListEntry.first.first_names).to eq("John James")
+    expect(ChildrensBarredListEntry.first.last_name).to eq("Smith")
     expect(ChildrensBarredListEntry.last.first_names).to eq("Jane Jemima")
+    expect(ChildrensBarredListEntry.last.last_name).to eq("Jones")
   end
 end


### PR DESCRIPTION
### Context

Searching the Children’s Barred List using accents/umlauts or uppercase/capital case should find results regardless of these variations.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Add postgresql `unaccent` extension.
- Use `unaccent` function in conjunction with lowercase search.
- Strip whitespace when importing name field data from CSV.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/6x3jyVL1/114-improve-case-accent-sensitive-search
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
