### PR TITLE
[111] Add example data to review apps

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -38,6 +38,7 @@ runs:
         echo "key_vault_name=$(jq -r '.key_vault_name' $TFVARS)" >> $GITHUB_ENV
         echo "key_vault_app_secret_name=$(jq -r '.key_vault_app_secret_name' $TFVARS)" >> $GITHUB_ENV
         echo "key_vault_infra_secret_name=$(jq -r '.key_vault_infra_secret_name'  $TFVARS)" >> $GITHUB_ENV
+        echo "namespace=$(jq -r '.namespace' $TFVARS)" >> $GITHUB_ENV
 
         if [ -n "${{ inputs.pr-number }}" ]; then
           APP_NAME=pr-${{ inputs.pr-number }}
@@ -111,3 +112,8 @@ runs:
       run: |
         az aks get-credentials -g ${{ env.cluster_rg }} -n ${{ env.cluster_name }}
         make install-konduit
+
+    - name: Generate example data
+      shell: bash
+      if: inputs.environment == 'review'
+      run: kubectl exec -n ${{ env.namespace }} deployment/check-childrens-barred-list-${APP_NAME} -- /bin/sh -c "cd /app && bundle exec rails example_data:generate"

--- a/Gemfile
+++ b/Gemfile
@@ -71,9 +71,12 @@ end
 
 group :test, :development do
   gem "dotenv-rails"
-  gem "factory_bot_rails"
   gem "launchy"
   gem "pry-byebug"
   gem "rspec"
   gem "rspec-rails"
+end
+
+group :development, :test, :review do
+  gem "factory_bot_rails"
 end

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -15,6 +15,19 @@ namespace :example_data do
     # information before attempting to generate factories
     ChildrensBarredListEntry.reset_column_information
 
-    FactoryBot.create(:childrens_barred_list_entry, date_of_birth: Date.new(1980, 1, 1))
+    entries = [
+      { first_names: "Mickey", last_name: "Mousé" },
+      { first_names: "John", last_name: "Doe" },
+      { first_names: "Ally", last_name: "Mc Ally" },
+    ]
+
+    entries.each do |entry|
+      FactoryBot.create(
+        :childrens_barred_list_entry,
+        first_names: entry[:first_names],
+        last_name: entry[:last_name],
+        date_of_birth: Date.new(1980, 1, 1)
+      )
+    end
   end
 end

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -1,0 +1,20 @@
+namespace :example_data do
+  desc "Create example data for testing"
+  task generate: :environment do
+    if HostingEnvironment.production?
+      raise "THIS TASK CANNOT BE RUN IN PRODUCTION"
+    end
+
+    if ChildrensBarredListEntry.any?
+      puts "Noop as DB already contains data"
+      exit
+    end
+
+    # Running `bundle exec rails db:migrate example_data:generate` can sometimes
+    # use cached column information. This forces rails to reload column
+    # information before attempting to generate factories
+    ChildrensBarredListEntry.reset_column_information
+
+    FactoryBot.create(:childrens_barred_list_entry, date_of_birth: Date.new(1980, 1, 1))
+  end
+end


### PR DESCRIPTION
### Context

We want to create review apps which are reviewable up until the point of finding an existing record.

### Changes proposed in this pull request

Create a ChildrensBarredListEntry in the database when we deploy review apps.
We can update the entries if we come across different scenarios that need testing, but for now i've gone with:
- Simple last name
- Last name with accent
- Last name with space in middle

All dates of birth are currently 1/1/1980 for ease of remembering, I couldn't think of a scenario which needed other dates to test.

### Guidance to review

In the review app, search for Doe, 1 Jan 1980 and check you get a result.

<img width="707" alt="Screenshot 2023-08-02 at 17 36 53" src="https://github.com/DFE-Digital/check-childrens-barred-list/assets/18436946/cafd359c-3d03-4e36-96ce-8832c8d0bf24">

### Link to Trello card

https://trello.com/c/DexhfPvY/112-seed-app

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally