### PR TITLE
[115] Search form snagging

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -15,7 +15,7 @@ class SearchesController < ApplicationController
     @search_form = SearchForm.new(search_params)
 
     if @search_form.valid?
-      render :no_record unless any_records?
+      render :no_record if record.nil?
     else
       render :new
     end
@@ -32,8 +32,8 @@ class SearchesController < ApplicationController
       end
   end
 
-  def any_records?
-    ChildrensBarredListEntry.includes_record?(
+  def record
+    @record ||= ChildrensBarredListEntry.search(
       last_name: @search_form.last_name,
       date_of_birth: @search_form.date_of_birth,
     )

--- a/app/models/childrens_barred_list_entry.rb
+++ b/app/models/childrens_barred_list_entry.rb
@@ -7,10 +7,10 @@ class ChildrensBarredListEntry < ApplicationRecord
             }
   validates :date_of_birth, presence: true
 
-  def self.includes_record?(last_name:, date_of_birth:)
+  def self.search(last_name:, date_of_birth:)
     where(
       "lower(unaccent(last_name)) = ?",
       ActiveSupport::Inflector.transliterate(last_name.strip.downcase)
-    ).and(where(date_of_birth:)).any?
+    ).and(where(date_of_birth:)).first
   end
 end

--- a/app/presenters/search_form_error_summary_presenter.rb
+++ b/app/presenters/search_form_error_summary_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SearchFormErrorSummaryPresenter
+  YEAR_FIELD = "#search_form_date_of_birth_1i"
+  YEAR_MESSAGE = I18n.t("activemodel.errors.models.search_form.attributes.date_of_birth.invalid_year")
+    
+  def initialize(error_messages)
+    @error_messages = error_messages
+  end
+
+  def formatted_error_messages    
+    @error_messages.map do |attribute, messages|
+      message = messages.first
+      message == YEAR_MESSAGE ? [attribute, message, YEAR_FIELD] : [attribute, message]
+    end
+  end
+end

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <%= form_with(model: @search_form, url: result_path, method: :get) do |f| %>
-      <%= f.govuk_error_summary "There’s a problem" %>
+      <%= f.govuk_error_summary("There’s a problem", presenter: SearchFormErrorSummaryPresenter) %>
 
       <h1 class="govuk-heading-l">Check the Children’s Barred List</h1>
 

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -2,10 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Check the Children’s Barred List</h1>
 
     <%= form_with(model: @search_form, url: result_path, method: :get) do |f| %>
-      <%= f.govuk_error_summary %>
+      <%= f.govuk_error_summary "There’s a problem" %>
+
+      <h1 class="govuk-heading-l">Check the Children’s Barred List</h1>
 
       <%= f.govuk_text_field :last_name, class: "govuk-input--width-20", label: { text: "Last name", size: "s" } %>
       <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: "Date of birth", size: "s" }, hint: { text: "For example, 31 3 #{40.years.ago.year}" } %>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -7,8 +7,8 @@
 
     <%= govuk_summary_list(
       rows: [
-        { key: { text: "Last name" }, value: { text: @search_form.last_name } },
-        { key: { text: "Date of birth" }, value: { text: @search_form.date_of_birth.to_fs(:long_uk) } }
+        { key: { text: "Last name" }, value: { text: @record.last_name } },
+        { key: { text: "Date of birth" }, value: { text: @record.date_of_birth.to_fs(:long_uk) } }
       ])
     %>
 

--- a/spec/models/childrens_barred_list_entry_spec.rb
+++ b/spec/models/childrens_barred_list_entry_spec.rb
@@ -5,83 +5,83 @@ RSpec.describe ChildrensBarredListEntry, type: :model do
   it { is_expected.to validate_presence_of(:last_name) }
   it { is_expected.to validate_presence_of(:date_of_birth) }
 
-  describe "#self.includes_record?" do
+  describe "#self.search" do
     let(:record) { create(:childrens_barred_list_entry) }
 
     context "with an exact match" do
-      it "returns true" do
+      it "returns the record" do
         expect(
-          described_class.includes_record?(
+          described_class.search(
             last_name: record.last_name,
             date_of_birth: record.date_of_birth,
           ),
-        ).to be_truthy
+        ).to eq(record)
       end
     end
 
     context "with a case-insensitive match on last_name" do
-      it "returns true" do
+      it "returns the record" do
         expect(
-          described_class.includes_record?(
+          described_class.search(
             last_name: record.last_name.downcase,
             date_of_birth: record.date_of_birth,
           ),
-        ).to be_truthy
+        ).to eq(record)
       end
     end
 
     context "with an accent-insensitive match on last_name" do
       it "returns true" do
         expect(
-          described_class.includes_record?(
+          described_class.search(
             last_name: "Doé",
             date_of_birth: record.date_of_birth,
           ),
-        ).to be_truthy
+        ).to eq(record)
       end
     end
 
     context "with a whitespace insensitive match on last_name" do
       it "returns true" do
         expect(
-          described_class.includes_record?(
+          described_class.search(
             last_name: " Doe ",
             date_of_birth: record.date_of_birth,
           ),
-        ).to be_truthy
+        ).to eq(record)
       end
     end
 
     context "with matching DoB but no matching last_name" do
-      it "returns false" do
+      it "returns nil" do
         expect(
-          described_class.includes_record?(
+          described_class.search(
             last_name: "Random name",
             date_of_birth: record.date_of_birth,
           ),
-        ).to be_falsey
+        ).to be_nil
       end
     end
 
     context "with matching last_name but no matching DoB" do
-      it "returns false" do
+      it "returns nil" do
         expect(
-          described_class.includes_record?(
+          described_class.search(
             last_name: record.last_name,
             date_of_birth: Time.zone.today,
           ),
-        ).to be_falsey
+        ).to be_nil
       end
     end
 
     context "with no matching DoB or last_name" do
-      it "returns false" do
+      it "returns nil" do
         expect(
-          described_class.includes_record?(
+          described_class.search(
             last_name: "Random name",
             date_of_birth: Time.zone.today,
           ),
-        ).to be_falsey
+        ).to be_nil
       end
     end
   end

--- a/spec/presenters/search_form_error_summary_presenter_spec.rb
+++ b/spec/presenters/search_form_error_summary_presenter_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe SearchFormErrorSummaryPresenter do
+  describe "#formatted_error_messages" do
+    subject(:presenter) { described_class.new({ date_of_birth: [message] }) }
+
+    describe "#formatted_error_messages" do
+      context "when the error relates to a non-year field" do
+        let(:message) { "Other error" }
+  
+        it "does not add a custom link" do
+          expect(presenter.formatted_error_messages).to eq([[:date_of_birth, message]])
+        end
+      end
+  
+      context "when the error relates to the year field" do
+        let(:message) { I18n.t("activemodel.errors.models.search_form.attributes.date_of_birth.invalid_year") }
+  
+        it "adds a custom link" do
+          expect(presenter.formatted_error_messages).to eq([[:date_of_birth, message, "#search_form_date_of_birth_1i"]])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Tweaks to search form following product review.

### Changes proposed in this pull request

- Move the error summary above h1

- In error summary:  'There is a problem' -> 'There's a problem'

- Make the year input focusable when the error is specifically about the year

- On the 'Record found' page: pull the data from the record found in the database, not the user’s search input

### Guidance to review

Check the above points have been addressed.

<img width="832" alt="Screenshot 2023-08-02 at 19 09 31" src="https://github.com/DFE-Digital/check-childrens-barred-list/assets/18436946/bd04d614-9a09-4203-9dad-83a84529d82e">

### Link to Trello card

https://trello.com/c/gOS9kgmQ/115-snagging-search-form-and-record-page

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally