### PR TITLE
Fix service name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 en:
   service:
-    name: Check the Childen’s Barred List
+    name: Check the Children’s Barred List
     email: employer.access@education.gov.uk
     dbs_email: dbscost@dbs.gov.uk
   activemodel:


### PR DESCRIPTION
### Context

"Children" is the accepted spelling of "Children".

### Changes proposed in this pull request

Use the accepted spelling in the service name.

### Guidance to review

https://www.oed.com/dictionary/child_n?tab=forms#9479630
