### PR TITLE
Remove test from deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [test, preproduction]
+        environment: [preproduction]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
### Context

We're going to run the pentest on this environment next week so temporarily removing it from the pipeline to avoid deploying during the test.

We'll revert this once the test is finished.

### Changes proposed in this pull request

Remove test from the deployment matrix.
