### PR TITLE
Downgrade to Sidekiq 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "okcomputer"
 gem "sentry-rails"
 gem "sentry-ruby"
 
-gem "sidekiq"
+gem "sidekiq", "<7"
 
 # Feature switching
 gem "govuk_feature_flags", github: "DFE-Digital/govuk_feature_flags", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,8 +301,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     rbs (2.8.4)
-    redis-client (0.14.1)
-      connection_pool
+    redis (4.8.1)
     regexp_parser (2.8.1)
     reline (0.3.5)
       io-console (~> 0.5)
@@ -373,11 +372,10 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.1.2)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.5.9)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -484,7 +482,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  sidekiq
+  sidekiq (< 7)
   solargraph
   solargraph-rails
   syntax_tree


### PR DESCRIPTION
### Context

Redis 7 is not available in Azure yet so we cant use Sidekiq 7

### Changes proposed in this pull request

Stick to Sidekiq < 7.

### Link to Trello card

https://trello.com/c/Rfu5KZPO/139-create-worker-app-via-aks

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally