### PR TITLE
CSV upload: Preview uploaded entries

### DIFF
--- a/app/controllers/support_interface/uploads_controller.rb
+++ b/app/controllers/support_interface/uploads_controller.rb
@@ -25,6 +25,16 @@ module SupportInterface
       if ConfirmChildrensBarredListEntries.new.call(upload_file_hash_param)
         redirect_to support_interface_upload_success_path
       else
+        @upload_file_hash = upload_file_hash_param
+        render :preview
+      end
+    end
+
+    def cancel
+      if DeleteUnconfirmedChildrensBarredListEntries.new.call(upload_file_hash_param)
+        redirect_to new_support_interface_upload_path
+      else
+        @upload_file_hash = upload_file_hash_param
         render :preview
       end
     end

--- a/app/controllers/support_interface/uploads_controller.rb
+++ b/app/controllers/support_interface/uploads_controller.rb
@@ -7,9 +7,25 @@ module SupportInterface
     def create
       @upload_form = UploadForm.new(upload_form_params)
       if @upload_form.save
-        redirect_to support_interface_upload_success_path
+        redirect_to support_interface_upload_preview_path(
+          upload_file_hash: @upload_form.upload_file_hash
+        )
       else
         render :new
+      end
+    end
+
+    def preview
+      @upload_file_hash = upload_file_hash_param
+      @unconfirmed_entries = ChildrensBarredListEntry
+        .where(confirmed: false, upload_file_hash: upload_file_hash_param)
+    end
+
+    def confirm
+      if ConfirmChildrensBarredListEntries.new.call(upload_file_hash_param)
+        redirect_to support_interface_upload_success_path
+      else
+        render :preview
       end
     end
 
@@ -17,6 +33,10 @@ module SupportInterface
 
     def upload_form_params
       params.fetch(:support_interface_upload_form, {}).permit(:file)
+    end
+
+    def upload_file_hash_param
+      params[:upload_file_hash]
     end
   end
 end

--- a/app/forms/support_interface/upload_form.rb
+++ b/app/forms/support_interface/upload_form.rb
@@ -2,14 +2,16 @@ module SupportInterface
   class UploadForm
     include ActiveModel::Model
 
-    attr_accessor :file
+    attr_accessor :file, :upload_file_hash
 
     validates :file, presence: true
 
     def save
       return false unless valid?
 
-      CreateChildrensBarredListEntries.new(file.read).call
+      service = CreateChildrensBarredListEntries.new(file.read)
+      @upload_file_hash = service.upload_file_hash
+      service.call
     rescue CSV::MalformedCSVError
       errors.add(:file, :invalid_csv)
       false

--- a/app/models/childrens_barred_list_entry.rb
+++ b/app/models/childrens_barred_list_entry.rb
@@ -11,6 +11,8 @@ class ChildrensBarredListEntry < ApplicationRecord
     where(
       "lower(unaccent(last_name)) = ?",
       ActiveSupport::Inflector.transliterate(last_name.strip.downcase)
-    ).and(where(date_of_birth:)).first
+    )
+    .where(date_of_birth:, confirmed: true)
+    .first
   end
 end

--- a/app/services/confirm_childrens_barred_list_entries.rb
+++ b/app/services/confirm_childrens_barred_list_entries.rb
@@ -1,0 +1,10 @@
+class ConfirmChildrensBarredListEntries
+  def call(upload_file_hash)
+    ChildrensBarredListEntry
+      .where(confirmed: false, upload_file_hash:)
+      .update_all(
+        confirmed: true,
+        confirmed_at: Time.zone.now,
+      )
+  end
+end

--- a/app/services/create_childrens_barred_list_entries.rb
+++ b/app/services/create_childrens_barred_list_entries.rb
@@ -3,24 +3,24 @@ require "csv"
 class CreateChildrensBarredListEntries
   TITLES_REGEX = /^(mr|mrs|miss|ms|dr|prof)\.? /i
 
+  attr_reader :upload_file_hash
+
   def initialize(raw_data)
     @raw_data = raw_data
+    @upload_file_hash = Digest::SHA256.hexdigest(raw_data)
   end
 
   def call
     CSV
       .parse(@raw_data)
       .each do |row|
-        entry = ChildrensBarredListEntry.find_or_initialize_by(
+        ChildrensBarredListEntry.create(
+          trn: pad_trn(row[0]),
           last_name: format_names(row[1]),
           first_names: format_names(row[2]),
           date_of_birth: row[3],
-        )
-        next if entry.trn.present? && entry.national_insurance_number.present?
-
-        entry.update!(
-          trn: pad_trn(row[0]),
           national_insurance_number: row[4],
+          upload_file_hash:,
         )
       end
   end
@@ -34,6 +34,6 @@ class CreateChildrensBarredListEntries
   def format_names(names)
     names.strip!
     names.gsub!(TITLES_REGEX, "")
-    names.split(" ").map(&:capitalize).join(" ")
+    names.downcase.split(" ").map(&:capitalize).join(" ")
   end
 end

--- a/app/services/delete_unconfirmed_childrens_barred_list_entries.rb
+++ b/app/services/delete_unconfirmed_childrens_barred_list_entries.rb
@@ -1,0 +1,7 @@
+class DeleteUnconfirmedChildrensBarredListEntries
+  def call(upload_file_hash)
+    ChildrensBarredListEntry
+      .where(confirmed: false, upload_file_hash:)
+      .delete_all
+  end
+end

--- a/app/views/support_interface/uploads/new.html.erb
+++ b/app/views/support_interface/uploads/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Upload records (CSV)" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @upload_form, url: [:support_interface, :uploads] do |f| %>

--- a/app/views/support_interface/uploads/preview.html.erb
+++ b/app/views/support_interface/uploads/preview.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Review and confirm" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Review and confirm</h1>

--- a/app/views/support_interface/uploads/preview.html.erb
+++ b/app/views/support_interface/uploads/preview.html.erb
@@ -1,35 +1,42 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full-width-from-desktop">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Review and confirm</h1>
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Last name</th>
-          <th scope="col" class="govuk-table__header">First names</th>
-          <th scope="col" class="govuk-table__header">Date of birth</th>
-          <th scope="col" class="govuk-table__header">TRN</th>
-          <th scope="col" class="govuk-table__header">NIN</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      <% @unconfirmed_entries.each do |entry| %>
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header"><%= entry.last_name %></th>
-          <td class="govuk-table__cell"><%= entry.first_names %></td>
-          <td class="govuk-table__cell"><%= entry.date_of_birth %></td>
-          <td class="govuk-table__cell"><%= entry.trn %></td>
-          <td class="govuk-table__cell"><%= entry.national_insurance_number %></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-    <div class="govuk-button-group">
-      <%= govuk_button_to("Confirm", support_interface_upload_confirm_path(upload_file_hash: @upload_file_hash)) %>
-      <%= govuk_button_to(
-        "Cancel",
-        support_interface_upload_cancel_path(upload_file_hash: @upload_file_hash),
-        class: "govuk-button--warning",
-      ) %>
-    </div>
+    <% if @unconfirmed_entries.empty? %>
+      <p class="govuk-body">No new entries found in upload.</p>
+      <p class="govuk-body">
+        <%= govuk_link_to("Upload another file", new_support_interface_upload_path) %>
+      </p>
+    <% else %>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Last name</th>
+            <th scope="col" class="govuk-table__header">First names</th>
+            <th scope="col" class="govuk-table__header">Date of birth</th>
+            <th scope="col" class="govuk-table__header">TRN</th>
+            <th scope="col" class="govuk-table__header">NIN</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <% @unconfirmed_entries.each do |entry| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= entry.last_name %></th>
+            <td class="govuk-table__cell"><%= entry.first_names %></td>
+            <td class="govuk-table__cell"><%= entry.date_of_birth %></td>
+            <td class="govuk-table__cell"><%= entry.trn %></td>
+            <td class="govuk-table__cell"><%= entry.national_insurance_number %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+      <div class="govuk-button-group">
+        <%= govuk_button_to("Confirm", support_interface_upload_confirm_path(upload_file_hash: @upload_file_hash)) %>
+        <%= govuk_button_to(
+          "Cancel",
+          support_interface_upload_cancel_path(upload_file_hash: @upload_file_hash),
+          class: "govuk-button--warning",
+        ) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/support_interface/uploads/preview.html.erb
+++ b/app/views/support_interface/uploads/preview.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full-width-from-desktop">
+    <h1 class="govuk-heading-l">Review and confirm</h1>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Last name</th>
+          <th scope="col" class="govuk-table__header">First names</th>
+          <th scope="col" class="govuk-table__header">Date of birth</th>
+          <th scope="col" class="govuk-table__header">TRN</th>
+          <th scope="col" class="govuk-table__header">NIN</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @unconfirmed_entries.each do |entry| %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= entry.last_name %></th>
+          <td class="govuk-table__cell"><%= entry.first_names %></td>
+          <td class="govuk-table__cell"><%= entry.date_of_birth %></td>
+          <td class="govuk-table__cell"><%= entry.trn %></td>
+          <td class="govuk-table__cell"><%= entry.national_insurance_number %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+    <%= govuk_button_to "Confirm", support_interface_upload_confirm_path(upload_file_hash: @upload_file_hash) %>
+  </div>
+</div>

--- a/app/views/support_interface/uploads/preview.html.erb
+++ b/app/views/support_interface/uploads/preview.html.erb
@@ -23,6 +23,13 @@
       <% end %>
       </tbody>
     </table>
-    <%= govuk_button_to "Confirm", support_interface_upload_confirm_path(upload_file_hash: @upload_file_hash) %>
+    <div class="govuk-button-group">
+      <%= govuk_button_to("Confirm", support_interface_upload_confirm_path(upload_file_hash: @upload_file_hash)) %>
+      <%= govuk_button_to(
+        "Cancel",
+        support_interface_upload_cancel_path(upload_file_hash: @upload_file_hash),
+        class: "govuk-button--warning",
+      ) %>
+    </div>
   </div>
 </div>

--- a/app/views/support_interface/uploads/success.html.erb
+++ b/app/views/support_interface/uploads/success.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Records uploaded" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <div class="govuk-panel govuk-panel--confirmation">

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -7,5 +7,8 @@ shared:
     - last_name
     - date_of_birth
     - national_insurance_number
+    - confirmed
+    - confirmed_at
+    - upload_file_hash
     - created_at
     - updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :uploads, only: %i[new create]
     get "/uploads/preview", to: "uploads#preview", as: :upload_preview
     post "/uploads/confirm", to: "uploads#confirm", as: :upload_confirm
+    post "/uploads/cancel", to: "uploads#cancel", as: :upload_cancel
     get "/uploads/success", to: "uploads#success", as: :upload_success
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
     mount FeatureFlags::Engine => "/features"
 
     resources :uploads, only: %i[new create]
+    get "/uploads/preview", to: "uploads#preview", as: :upload_preview
+    post "/uploads/confirm", to: "uploads#confirm", as: :upload_confirm
     get "/uploads/success", to: "uploads#success", as: :upload_success
   end
 end

--- a/db/migrate/20230815100111_add_confirmation_fields_to_childrens_barred_list_entries.rb
+++ b/db/migrate/20230815100111_add_confirmation_fields_to_childrens_barred_list_entries.rb
@@ -1,0 +1,9 @@
+class AddConfirmationFieldsToChildrensBarredListEntries < ActiveRecord::Migration[7.0]
+  def change
+    change_table :childrens_barred_list_entries, bulk: true do |t|
+      t.boolean :confirmed, default: false, null: false
+      t.datetime :confirmed_at
+      t.string :upload_file_hash
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,6 +23,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_15_140331) do
     t.string "national_insurance_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "confirmed", default: false, null: false
+    t.datetime "confirmed_at"
+    t.string "upload_file_hash"
     t.index ["first_names", "last_name", "date_of_birth"], name: "index_childrens_barred_list_entries_on_names_and_dob", unique: true
   end
 

--- a/spec/factories/childrens_barred_list_entries.rb
+++ b/spec/factories/childrens_barred_list_entries.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     first_names { "John" }
     last_name { "Doe" }
     date_of_birth { 25.years.ago }
+    confirmed { true }
+    confirmed_at { 1.day.ago }
+    upload_file_hash { Digest::SHA256.hexdigest("test") }
+
+    trait :unconfirmed do
+      confirmed { false }
+      confirmed_at { nil }
+    end
   end
 end

--- a/spec/forms/support_interface/upload_form_spec.rb
+++ b/spec/forms/support_interface/upload_form_spec.rb
@@ -23,9 +23,16 @@ RSpec.describe SupportInterface::UploadForm, type: :model do
       end
 
       subject(:form) { described_class.new(file: StringIO.new(csv_data)) }
+      let(:save!) { form.save }
 
       it "creates a new ChildrensBarredListEntry for each row in the CSV" do
         expect { form.save }.to change { ChildrensBarredListEntry.count }.by(2)
+      end
+
+      it "populates the upload_file_hash attribute" do
+        save!
+        expect(ChildrensBarredListEntry.first.upload_file_hash).to eq(Digest::SHA256.hexdigest(csv_data))
+        expect(ChildrensBarredListEntry.last.upload_file_hash).to eq(Digest::SHA256.hexdigest(csv_data))
       end
     end
 

--- a/spec/models/childrens_barred_list_entry_spec.rb
+++ b/spec/models/childrens_barred_list_entry_spec.rb
@@ -84,5 +84,17 @@ RSpec.describe ChildrensBarredListEntry, type: :model do
         ).to be_nil
       end
     end
+
+    context "with an unconfirmed record" do
+      let(:record) { create(:childrens_barred_list_entry, :unconfirmed) }
+      it "returns nil" do
+        expect(
+          described_class.search(
+            last_name: record.last_name,
+            date_of_birth: record.date_of_birth,
+          ),
+        ).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/confirm_childrens_barred_list_entries_spec.rb
+++ b/spec/services/confirm_childrens_barred_list_entries_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ConfirmChildrensBarredListEntries do
+  let(:unconfirmed_entry) { create(:childrens_barred_list_entry, :unconfirmed) }
+
+  subject(:service) { described_class.new }
+
+  describe "#call" do
+    it "confirms all unconfirmed entries matching the upload hash" do
+      another_unconfirmed_entry = create(
+        :childrens_barred_list_entry,
+        :unconfirmed,
+        last_name: "Brown",
+        upload_file_hash: "123",
+      )
+
+      service.call(unconfirmed_entry.upload_file_hash)
+
+      expect(unconfirmed_entry.reload).to be_confirmed
+      expect(unconfirmed_entry.confirmed_at).to be_present
+      expect(another_unconfirmed_entry.reload).not_to be_confirmed
+    end
+  end
+end

--- a/spec/services/create_childrens_barred_list_entries_spec.rb
+++ b/spec/services/create_childrens_barred_list_entries_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CreateChildrensBarredListEntries do
   end
 
   it "sets the upload_file_hash" do
-    service.call
-    expect(ChildrensBarredListEntry.first.upload_file_hash).to eq(Digest::SHA256.hexdigest(csv_data))
+    expect(service.upload_file_hash).not_to be_nil
+    expect(service.upload_file_hash).to eq(Digest::SHA256.hexdigest(csv_data))
   end
 end

--- a/spec/services/create_childrens_barred_list_entries_spec.rb
+++ b/spec/services/create_childrens_barred_list_entries_spec.rb
@@ -14,17 +14,6 @@ RSpec.describe CreateChildrensBarredListEntries do
     expect { service.call }.to change { ChildrensBarredListEntry.count }.by(2)
   end
 
-  it "updates existing matching entries" do
-    existing_entry = ChildrensBarredListEntry.create!(
-      last_name: "Jones",
-      first_names: "Jane Jemima",
-      date_of_birth: "07/05/1980"
-    )
-    service.call
-    expect(existing_entry.reload.trn).to eq("1234568")
-    expect(existing_entry.national_insurance_number ).to eq("AB123456D")
-  end
-
   it "zero pads the TRN" do
     service.call
     expect(ChildrensBarredListEntry.first.trn).to eq("0012567")
@@ -36,5 +25,15 @@ RSpec.describe CreateChildrensBarredListEntries do
     expect(ChildrensBarredListEntry.first.last_name).to eq("Smith")
     expect(ChildrensBarredListEntry.last.first_names).to eq("Jane Jemima")
     expect(ChildrensBarredListEntry.last.last_name).to eq("Jones")
+  end
+
+  it "sets the confirmed field to false" do
+    service.call
+    expect(ChildrensBarredListEntry.first.confirmed).to eq(false)
+  end
+
+  it "sets the upload_file_hash" do
+    service.call
+    expect(ChildrensBarredListEntry.first.upload_file_hash).to eq(Digest::SHA256.hexdigest(csv_data))
   end
 end

--- a/spec/services/delete_unconfirmed_childrens_barred_list_entries_spec.rb
+++ b/spec/services/delete_unconfirmed_childrens_barred_list_entries_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe DeleteUnconfirmedChildrensBarredListEntries do
+  let(:unconfirmed_entry) { create(:childrens_barred_list_entry, :unconfirmed) }
+
+  subject(:service) { described_class.new }
+
+  describe "#call" do
+    it "deletes all unconfirmed entries matching the upload hash" do
+      another_unconfirmed_entry = create(
+        :childrens_barred_list_entry,
+        :unconfirmed,
+        last_name: "Brown",
+        upload_file_hash: "123",
+      )
+
+      service.call(unconfirmed_entry.upload_file_hash)
+
+      expect(ChildrensBarredListEntry.count).to eq(1)
+      expect(ChildrensBarredListEntry.first).to eq(another_unconfirmed_entry)
+    end
+  end
+end

--- a/spec/system/support_interface/support_user_uploads_a_csv_file_spec.rb
+++ b/spec/system/support_interface/support_user_uploads_a_csv_file_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "Upload file", type: :system do
     and_i_am_signed_in_via_dsi
     and_i_am_on_the_upload_page
     when_i_upload_a_valid_csv_file
+    then_i_see_a_preview_of_the_data
+    when_i_confirm_the_upload
     then_i_see_a_success_message
   end
 
@@ -24,6 +26,29 @@ RSpec.describe "Upload file", type: :system do
     attach_file "support_interface_upload_form[file]",
                 Rails.root.join("spec/fixtures/example.csv")
     click_on "Upload file"
+  end
+
+  def then_i_see_a_preview_of_the_data
+    expect(page).to have_content("Review and confirm")
+    within("table thead") do
+      expect(page).to have_content("Last name")
+      expect(page).to have_content("First names")
+      expect(page).to have_content("Date of birth")
+      expect(page).to have_content("TRN")
+      expect(page).to have_content("NIN")
+    end
+
+    within("table tbody") do
+      expect(page).to have_content("Simpson")
+      expect(page).to have_content("Homer Duff")
+
+      expect(page).to have_content("Banner")
+      expect(page).to have_content("Bruce Angry")
+    end
+  end
+
+  def when_i_confirm_the_upload
+    click_on "Confirm"
   end
 
   def then_i_see_a_success_message

--- a/spec/system/support_interface/support_user_uploads_a_csv_file_spec.rb
+++ b/spec/system/support_interface/support_user_uploads_a_csv_file_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe "Upload file", type: :system do
     and_i_am_on_the_upload_page
     when_i_upload_a_valid_csv_file
     then_i_see_a_preview_of_the_data
+    when_i_cancel_the_upload
+    then_i_am_redirected_to_the_upload_page
+    and_unconfirmed_entries_are_removed
+    when_i_upload_a_valid_csv_file
     when_i_confirm_the_upload
     then_i_see_a_success_message
   end
@@ -21,6 +25,8 @@ RSpec.describe "Upload file", type: :system do
   def and_i_am_on_the_upload_page
     visit new_support_interface_upload_path
   end
+
+  alias_method :then_i_am_redirected_to_the_upload_page, :and_i_am_on_the_upload_page
 
   def when_i_upload_a_valid_csv_file
     attach_file "support_interface_upload_form[file]",
@@ -45,6 +51,14 @@ RSpec.describe "Upload file", type: :system do
       expect(page).to have_content("Banner")
       expect(page).to have_content("Bruce Angry")
     end
+  end
+
+  def when_i_cancel_the_upload
+    click_on "Cancel"
+  end
+
+  def and_unconfirmed_entries_are_removed
+    expect(ChildrensBarredListEntry.count).to eq(0)
   end
 
   def when_i_confirm_the_upload


### PR DESCRIPTION
### Context

As a support user uploading CSV data to the barred list
I would like to be able to preview the data before confirming it should be saved.


<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a preview step when uploading CSV data, in order to do this we need to mark new entries as unconfirmed until they are explicitly confirmed on the preview screen.
Also adds a cancellation step which removes any unconfirmed entries relating to the current file upload.

#### Preview step
![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/0effe42b-6a9b-4f24-966d-7561fdcf73a1)


#### No new entries in file upload
![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/182785e4-cda0-4d1a-825a-0fba18d61d14)


#### Not in scope for this PR

If a user exits the page without confirming or cancelling, unconfirmed entries will remain in the db. 
We could clean these up with a scheduled task or manually with a rake task.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/zCVoBvFY/143-csv-upload-add-check-uploaded-entries-flow

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
