### PR TITLE
[147] Update h1s on record found and not found pages

### DIFF
--- a/app/views/searches/no_record.html.erb
+++ b/app/views/searches/no_record.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">No record found</h1>
+    <h1 class="govuk-heading-l">No record found on the Children’s Barred List</h1>
 
     <%= govuk_summary_list(
       rows: [

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Record found</h1>
+    <h1 class="govuk-heading-l">Record found on the Children’s Barred List</h1>
 
     <%= govuk_summary_list(
       rows: [


### PR DESCRIPTION
### Context

Some users were confused by what we meant by 'Record found' and 'Record not found'.

### Changes proposed in this pull request

Update the h1s as per this design history: https://tra-digital-design-history.herokuapp.com/check-the-childrens-barred-list/clarifying-which-records-are-searched/

### Guidance to review
<img width="1164" alt="Screenshot 2023-08-21 at 11 18 58" src="https://github.com/DFE-Digital/check-childrens-barred-list/assets/18436946/5c4c80d4-4a64-4946-a069-b5b5e8b5efc5">

<img width="1164" alt="Screenshot 2023-08-21 at 11 18 27" src="https://github.com/DFE-Digital/check-childrens-barred-list/assets/18436946/315b6564-f16f-4d66-8a3b-e1f853d945f6">

### Link to Trello card

https://trello.com/c/ejIKGC3l/147-record-found-not-found-content

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally