### PR TITLE
Add organisation and profile to scope array

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -26,6 +26,6 @@ else
              discovery: true,
              issuer: "#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}",
              response_type: :code,
-             scope: %i[email first_name last_name]
+             scope: %i[email organisation profile]
   end
 end


### PR DESCRIPTION
### Context

We need to restrict access to the service so that only DfE staff and agencies have access. The plan is to do this by checking against a list we manage in the service, using data sent by DSI.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adding organisation to the scope array will return data related to the organisation claim in the response from DSI after successful authentication. Specifically, in "extra"."raw_info"."organisation". The "companyRegistrationNumber" in there is what we'll use to check a hardcoded list of agencies.


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
