### PR TITLE
Clean up old unconfirmed records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem "omniauth-rails_csrf_protection"
 # Sending events to BigQuery
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.10.1"
 
+# Scheduling jobs
+gem "clockwork"
+
 group :development do
   gem "prettier_print", require: false
   gem "rladr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    clockwork (3.0.2)
+      activesupport
+      tzinfo
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -517,6 +520,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  clockwork
   cssbundling-rails
   cuprite
   debug

--- a/app/workers/delete_unconfirmed_entries_worker.rb
+++ b/app/workers/delete_unconfirmed_entries_worker.rb
@@ -1,0 +1,7 @@
+class DeleteUnconfirmedEntriesWorker < ApplicationJob
+  def perform
+    ChildrensBarredListEntry
+      .where(confirmed: false)
+      .destroy_all
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -1,0 +1,6 @@
+require 'clockwork'
+require 'active_support/time' # Allow numeric durations (eg: 1.minutes)
+
+module Clockwork
+  every(1.day, "DeleteUnconfirmedEntries.perform_later", at: "00:00")
+end

--- a/spec/workers/delete_unconfirmed_entries_worker_spec.rb
+++ b/spec/workers/delete_unconfirmed_entries_worker_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe DeleteUnconfirmedEntriesWorker do
+  describe "#perform" do
+    before do
+      create(:childrens_barred_list_entry, last_name: "Smith")
+      create(:childrens_barred_list_entry, :unconfirmed, last_name: "Wilson")
+    end
+
+    it "deletes the unconfirmed entry" do
+      expect { DeleteUnconfirmedEntriesWorker.new.perform }
+        .to change { ChildrensBarredListEntry.count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
### Context

When a CSV file is uploaded the records are saved in an unconfirmed state and then confirmed in the following preview step.
If the user navigates away from the preview step without confirming these unconfirmed entries will remain in the database.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Schedule a nightly cleanup of unconfirmed `ChildrensBarredListEntry` records.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/Lo4ilIdx/160-clean-up-old-unconfirmed-records
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
