### PR TITLE
Check user access to service on sign in

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,13 @@
 BYPASS_DSI=true
 HOSTING_ENVIRONMENT=local
+
+DFE_SIGN_IN_API_BASE_URL=https://dev-api.signin.education.gov.uk
+DFE_SIGN_IN_API_SECRET=override-locally
+DFE_SIGN_IN_API_AUDIENCE=signin.education.gov.uk
+DFE_SIGN_IN_API_ROLE_CODES=override-locally
+
 DFE_SIGN_IN_CLIENT_ID=ctcbl
 DFE_SIGN_IN_REDIRECT_URL=http://localhost:3000/auth/dfe/callback
 DFE_SIGN_IN_SECRET=override-locally
 DFE_SIGN_IN_ISSUER=https://dev-oidc.signin.education.gov.uk
+

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+DFE_SIGN_IN_API_BASE_URL=https://dev-api.signin.education.gov.uk
+DFE_SIGN_IN_API_SECRET=override-locally
+DFE_SIGN_IN_API_AUDIENCE=signin.education.gov.uk
+DFE_SIGN_IN_API_ROLE_CODES=override-locally

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,9 @@
 DFE_SIGN_IN_API_BASE_URL=https://dev-api.signin.education.gov.uk
-DFE_SIGN_IN_API_SECRET=override-locally
+DFE_SIGN_IN_API_SECRET=test
 DFE_SIGN_IN_API_AUDIENCE=signin.education.gov.uk
-DFE_SIGN_IN_API_ROLE_CODES=override-locally
+DFE_SIGN_IN_API_ROLE_CODES=test
+
+DFE_SIGN_IN_CLIENT_ID=checkchildrensbarredlist
+DFE_SIGN_IN_REDIRECT_URL=test
+DFE_SIGN_IN_SECRET=test
+DFE_SIGN_IN_ISSUER=test

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :test do
   gem "capybara"
   gem "cuprite"
   gem "shoulda-matchers"
+  gem "webmock"
 end
 
 group :test, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.1"
 # Scheduling jobs
 gem "clockwork"
 
+# Generate JSON Web Tokens
+gem "jwt"
+
 group :development do
   gem "prettier_print", require: false
   gem "rladr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.3.3)
       railties (>= 6.0.0)
@@ -205,6 +207,7 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
+    hashdiff (1.0.1)
     hashie (5.0.0)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
@@ -529,6 +532,10 @@ GEM
       activesupport
       faraday (~> 2.0)
       faraday-follow_redirects
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -583,6 +590,7 @@ DEPENDENCIES
   syntax_tree-rbs
   tzinfo-data
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,6 +556,7 @@ DEPENDENCIES
   govuk_feature_flags!
   govuk_markdown
   jsbundling-rails
+  jwt
   launchy
   okcomputer
   omniauth-oauth2 (~> 1.8)

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_dsi_user!
+  skip_before_action :handle_expired_session!
+
+  def not_authorised
+    render 'not_authorised', status: :unauthorized
+  end
+end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -14,7 +14,7 @@ class OmniauthCallbacksController < ApplicationController
         user_id: auth.uid,
       ).call
 
-      return head(:unauthorized) unless role
+      return redirect_to not_authorised_path unless role
     end
 
     @dsi_user = DsiUser.create_or_update_from_dsi(auth, role)

--- a/app/lib/dfe_sign_in_api/client.rb
+++ b/app/lib/dfe_sign_in_api/client.rb
@@ -1,0 +1,35 @@
+require "jwt"
+
+module DfESignInApi
+  module Client
+    TIMEOUT_IN_SECONDS = 5
+
+    def client
+      @client ||=
+        Faraday.new(
+          url: ENV.fetch("DFE_SIGN_IN_API_BASE_URL"),
+          request: {
+            timeout: TIMEOUT_IN_SECONDS
+          }
+        ) do |faraday|
+          faraday.request :authorization, "Bearer", jwt
+          faraday.request :json
+          faraday.response :json
+          faraday.adapter Faraday.default_adapter
+        end
+    end
+
+    private
+
+    def jwt
+      @jwt ||= JWT.encode(
+        {
+          iss: ENV.fetch("DFE_SIGN_IN_CLIENT_ID"),
+          aud: ENV.fetch("DFE_SIGN_IN_API_AUDIENCE"),
+        },
+        ENV.fetch("DFE_SIGN_IN_API_SECRET"),
+        "HS256",
+      )
+    end
+  end
+end

--- a/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
+++ b/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
@@ -1,0 +1,34 @@
+module DfESignInApi
+  class GetUserAccessToService
+    include Client
+
+    attr_reader :org_id, :user_id
+
+    def initialize(org_id:, user_id:)
+      @org_id = org_id
+      @user_id = user_id
+    end
+
+    def call
+      response = client.get(endpoint)
+
+      if response.success? && response.body.key?("roles")
+        response.body["roles"].find { |role| authorised_role_codes.include?(role["code"]) }
+      end
+    end
+
+    private
+
+    def endpoint
+      "/services/#{service_id}/organisations/#{org_id}/users/#{user_id}"
+    end
+
+    def service_id
+      ENV["DFE_SIGN_IN_CLIENT_ID"]
+    end
+
+    def authorised_role_codes
+      ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",")
+    end
+  end
+end

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -1,5 +1,7 @@
 class DsiUser < ApplicationRecord
-  def self.create_or_update_from_dsi(dsi_payload)
+  has_many :dsi_user_sessions, dependent: :destroy
+
+  def self.create_or_update_from_dsi(dsi_payload, role = nil)
     dsi_user = find_or_initialize_by(email: dsi_payload.info.fetch(:email))
 
     dsi_user.update!(
@@ -7,6 +9,15 @@ class DsiUser < ApplicationRecord
       last_name: dsi_payload.info.last_name,
       uid: dsi_payload.uid
     )
+
+    if role.present?
+      dsi_user.dsi_user_sessions.create!(
+        role_id: role["id"],
+        role_code: role["code"],
+        organisation_id: dsi_payload.extra.raw_info.organisation.id,
+        organisation_name: dsi_payload.extra.raw_info.organisation.name,
+      )
+    end
 
     dsi_user
   end

--- a/app/models/dsi_user_session.rb
+++ b/app/models/dsi_user_session.rb
@@ -1,0 +1,3 @@
+class DsiUserSession < ApplicationRecord
+  belongs_to :dsi_user
+end

--- a/app/views/errors/not_authorised.html.erb
+++ b/app/views/errors/not_authorised.html.erb
@@ -1,0 +1,10 @@
+<%= content_for :page_title, "Not authorised" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Authorisation required</h1>
+    <p class="govuk-body">
+      You are not authorised to access this service.
+    </p>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -8,6 +8,15 @@ shared:
     - uid
     - created_at
     - updated_at
+  :dsi_user_sessions:
+    - id
+    - dsi_user_id
+    - role_id
+    - role_code
+    - organisation_id
+    - organisation_name
+    - created_at
+    - updated_at
   :feature_flags_features:
     - id
     - name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
   get "/accessibility", to: "static#accessibility"
   get "/cookies", to: "static#cookies"
 
+  get '/401', to: 'errors#not_authorised', as: :not_authorised
+
   namespace :support_interface, path: "/support" do
     root to: redirect("/support/features")
 

--- a/db/migrate/20230918084304_create_dsi_user_sessions.rb
+++ b/db/migrate/20230918084304_create_dsi_user_sessions.rb
@@ -1,0 +1,12 @@
+class CreateDsiUserSessions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dsi_user_sessions do |t|
+      t.belongs_to :dsi_user
+      t.string :role_id
+      t.string :role_code
+      t.string :organisation_id
+      t.string :organisation_name
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_15_140331) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_18_084304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -27,6 +27,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_15_140331) do
     t.datetime "confirmed_at"
     t.string "upload_file_hash"
     t.index ["first_names", "last_name", "date_of_birth"], name: "index_childrens_barred_list_entries_on_names_and_dob", unique: true
+  end
+
+  create_table "dsi_user_sessions", force: :cascade do |t|
+    t.bigint "dsi_user_id"
+    t.string "role_id"
+    t.string "role_code"
+    t.string "organisation_id"
+    t.string "organisation_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dsi_user_id"], name: "index_dsi_user_sessions_on_dsi_user_id"
   end
 
   create_table "dsi_users", force: :cascade do |t|
@@ -55,4 +66,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_15_140331) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
 end

--- a/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
+++ b/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe DfESignInApi::GetUserAccessToService do
+  describe "#call" do
+    let(:org_id) { "123" }
+    let(:user_id) { "456" }
+    let(:role_id) { "789" }
+    let(:role_code) { ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first }
+    let(:endpoint) do
+      "#{ENV.fetch("DFE_SIGN_IN_API_BASE_URL")}/services/checkchildrensbarredlist/organisations/#{org_id}/users/#{user_id}"
+    end
+
+    subject { described_class.new(org_id:, user_id:).call }
+
+    context "when the user is authorised" do
+      before do
+        stub_request(:get, endpoint)
+        .to_return_json(
+          status: 200,
+          body: { "roles" => [{ "id" => role_id, "code" => role_code }] },
+        )
+      end
+
+      it { is_expected.to eq({ "id" => role_id, "code" => role_code }) }
+    end
+
+    context "when the user is not authorised" do
+      before do
+        stub_request(:get, endpoint)
+        .to_return_json(
+          status: 200,
+          body: { "roles" => [{ "id" => role_id, "code" => "Unauthorised_Role" }] },
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
+++ b/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe DfESignInApi::GetUserAccessToService do
     let(:role_id) { "789" }
     let(:role_code) { ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first }
     let(:endpoint) do
-      "#{ENV.fetch("DFE_SIGN_IN_API_BASE_URL")}/services/checkchildrensbarredlist/organisations/#{org_id}/users/#{user_id}"
+      [
+        ENV.fetch("DFE_SIGN_IN_API_BASE_URL"),
+        "/services/checkchildrensbarredlist/organisations/#{org_id}/users/#{user_id}"
+      ].join
     end
 
     subject { described_class.new(org_id:, user_id:).call }

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -3,7 +3,18 @@ require "rails_helper"
 RSpec.describe DsiUser, type: :model do
   describe ".create_or_update_from_dsi" do
     let(:dsi_payload) do
-      OmniAuth::AuthHash.new(uid: "123456", info: { email:, first_name: "John", last_name: "Doe" })
+      OmniAuth::AuthHash.new(
+        uid: "123456",
+        info: { email:, first_name: "John", last_name: "Doe" },
+        extra: {
+          raw_info: {
+            organisation: {
+              id: "09876",
+              name: "Test Org",
+            }
+          }
+        }
+      )
     end
     let(:email) { "test@example.com" }
 
@@ -30,6 +41,20 @@ RSpec.describe DsiUser, type: :model do
         expect(dsi_user.uid).to eq dsi_payload.uid
         expect(dsi_user.first_name).to eq dsi_payload.info.first_name
         expect(dsi_user.last_name).to eq dsi_payload.info.last_name
+      end
+    end
+
+    context "when the user has a role" do
+      it "creates a session record" do
+        role = { "id" => "123", "code" => "TestRole_code" }
+        described_class.create_or_update_from_dsi(dsi_payload, role)
+
+        dsi_user_session = DsiUser.first.dsi_user_sessions.first
+        expect(dsi_user_session).to be_present
+        expect(dsi_user_session.role_id).to eq "123"
+        expect(dsi_user_session.role_code).to eq "TestRole_code"
+        expect(dsi_user_session.organisation_id).to eq "09876"
+        expect(dsi_user_session.organisation_name).to eq "Test Org"
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,10 +9,13 @@ end
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require "capybara/cuprite"
 require "dfe/analytics/testing"
 require "dfe/analytics/rspec/matchers"
+require "webmock/rspec"
 
-require "capybara/cuprite"
+WebMock.disable_net_connect!(allow_localhost: true)
+
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -1,12 +1,12 @@
 module AuthenticationSteps
-  def when_i_sign_in_via_dsi
-    given_dsi_auth_is_mocked
+  def when_i_sign_in_via_dsi(authorised: true)
+    given_dsi_auth_is_mocked(authorised:)
     when_i_visit_the_sign_in_page
     and_click_the_dsi_sign_in_button
   end
   alias_method :and_i_am_signed_in_via_dsi, :when_i_sign_in_via_dsi
 
-  def given_dsi_auth_is_mocked
+  def given_dsi_auth_is_mocked(authorised:)
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       {
         provider: "dfe",
@@ -15,9 +15,35 @@ module AuthenticationSteps
           email: "test@example.com",
           first_name: "Test",
           last_name: "User"
+        },
+        extra: {
+          raw_info: {
+            organisation: {
+              id: org_id,
+            }
+          }
         }
       }
     )
+
+    stub_request(
+      :get, user_roles_endpoint
+    ).to_return_json(
+      status: 200,
+      body: { "roles" => [{ "code" => (authorised ? role_code : "Unauthorised_Role") }] },
+    )
+  end
+
+  def user_roles_endpoint
+    "#{ENV.fetch("DFE_SIGN_IN_API_BASE_URL")}/services/checkchildrensbarredlist/organisations/#{org_id}/users/123456"
+  end
+
+  def org_id
+    "12345678-1234-1234-1234-123456789012"
+  end
+
+  def role_code
+    ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first
   end
 
   def when_i_visit_the_sign_in_page

--- a/spec/system/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/unauthorised_user_signs_in_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DSI authentication", type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  scenario "Unauthorised user signs in via DfE Sign In", test: :with_stubbed_auth do
+    given_the_service_is_open
+    when_i_sign_in_via_dsi(authorised: false)
+    then_i_am_not_authorised
+  end
+
+  private
+
+  def then_i_am_not_authorised
+    expect(page.status_code).to eq 401
+  end
+end

--- a/spec/system/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/unauthorised_user_signs_in_spec.rb
@@ -16,5 +16,6 @@ RSpec.describe "DSI authentication", type: :system do
 
   def then_i_am_not_authorised
     expect(page.status_code).to eq 401
+    expect(page).to have_content("You are not authorised to access this service")
   end
 end

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -17,5 +17,6 @@ RSpec.describe "DSI authentication", type: :system do
   def then_i_am_signed_in
     within("header") { expect(page).to have_content "Sign out" }
     expect(DsiUser.count).to eq 1
+    expect(DsiUserSession.count).to eq 1
   end
 end


### PR DESCRIPTION
### Context

<!-- Why are you making this change? -->
We'd like to check the user's assigned roles on sign in.
The DfE Signin API [exposes an endpoint](https://github.com/DFE-Digital/login.dfe.public-api#get-user-access-to-service) which replies with user roles for a given user, service and organisation.

Ports across code [implemented](https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/333) by @steventux in the Check the record of a teacher service, with some minor changes to error handling and specs.

### Changes proposed in this pull request

-  Call the DfE Sign in API get user access to service endpoint as part of the DSI login journey.
-  Authorise user based on presence of valid role for service, valid role codes are stored in ENV["DFE_SIGN_IN_API_ROLE_CODES"]
-  Create a DsiUserSession record on each successful login (except when bypass is active). This record contains the role and org info the user authenticated with.
- Add an Errors controller to show a custom 401.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
~~It isn't really possible to test this without a role being set up for the service in DSI Manage. I've also marked it as Do Not Merge until the env var setup is complete in dev/test/preprod.~~

~~Raising as draft initially for early feedback.~~

This can now be tested locally via the DSI dev environment.

- Attempt to sign in — you should see a not authorised message.
- In the [dev DSI Manage](https://dev-services.signin.education.gov.uk/), add yourself to the Children's barred list service. Any organisation will work. You should be able to see the "University" role as an option when adding. 
- Ensure you've set dev values for DFE_SIGN_IN_API_SECRET and DFE_SIGN_IN_SECRET, both available in the Manage console.
- Set DFE_SIGN_IN_API_ROLE_CODES to `CheckChildrensBarredList_University`
- Restart the app.
- Signing in should now work.


<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/Hh6sh7Np/188-check-user-roles-on-sign-in-via-dsi
<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Add required env vars to CBL test/preprod enviroments
- [x] Attach to Trello card
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
