### PR TITLE
Signin is always enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ RUN rm -rf node_modules log/* tmp/* /tmp && \
 # Build runtime image
 FROM ruby:3.2.2-alpine as production
 
+# Upgrade ssl, crypto and curl libraries to latest version
+RUN apk upgrade --no-cache openssl libssl3 libcrypto3 curl
+
 # The application runs from /app
 WORKDIR /app
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,8 @@ class ApplicationController < ActionController::Base
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   before_action :http_basic_authenticate, unless: -> { FeatureFlags::FeatureFlag.active?(:service_open) }
-  before_action :authenticate_dsi_user!, if: -> { FeatureFlags::FeatureFlag.active?(:service_open) }
-  before_action :handle_expired_session!, if: -> { FeatureFlags::FeatureFlag.active?(:service_open) }
+  before_action :authenticate_dsi_user!
+  before_action :handle_expired_session!
 
   def http_basic_authenticate
     valid_credentials = [

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -15,9 +15,10 @@ RSpec.describe "Authentication", type: :request do
         )
       end
 
-      it "returns http success" do
+      it "redirects to sign-in" do
         get "/", env: { "HTTP_AUTHORIZATION" => credentials }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to("/sign-in")
       end
     end
   end


### PR DESCRIPTION
### Context

We've overloaded the :service_open feature flag so it's not possible to enable DfE Signin without removing basic authentication.

### Changes proposed in this pull request

Remove the feature flag to always enable DSI.
Update some packages that were causing Snyk to fail

We already have a BYPASS_DSI environment variable we can use locally.

