### PR TITLE
Add workflow dispatch to build and deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,16 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment"
+        required: true
+        type: choice
+        options:
+          - test
+          - preproduction
+          - production
 
 permissions:
   contents: write


### PR DESCRIPTION
Enable manual deploys from Github

### Context

We currently don't have the ability to manually deploy. 

### Changes proposed in this pull request

Add a workflow_dispatch to the build_and_deploy.yml workflow