### PR TITLE
Staff role authorisation

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@ DFE_SIGN_IN_API_BASE_URL=https://dev-api.signin.education.gov.uk
 DFE_SIGN_IN_API_SECRET=test
 DFE_SIGN_IN_API_AUDIENCE=signin.education.gov.uk
 DFE_SIGN_IN_API_ROLE_CODES=test
-
+DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE=internal
 DFE_SIGN_IN_CLIENT_ID=checkchildrensbarredlist
 DFE_SIGN_IN_REDIRECT_URL=test
 DFE_SIGN_IN_SECRET=test

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "sentry-rails"
 gem "sentry-ruby"
 
 gem "sidekiq", "<7"
+gem "sidekiq-cron"
 
 # Feature switching
 gem "govuk_feature_flags", github: "DFE-Digital/govuk_feature_flags", branch: "main"
@@ -58,6 +59,8 @@ gem "clockwork"
 
 # Generate JSON Web Tokens
 gem "jwt"
+
+gem 'activerecord-session_store'
 
 group :development do
   gem "prettier_print", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,13 @@ GEM
       activemodel (= 7.1.2)
       activesupport (= 7.1.2)
       timeout (>= 0.4.0)
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     activestorage (7.1.2)
       actionpack (= 7.1.2)
       activejob (= 7.1.2)
@@ -116,6 +123,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.1)
     clockwork (3.0.2)
       activesupport
       tzinfo
@@ -144,6 +152,8 @@ GEM
       ruby2_keywords
     e2mmap (0.1.0)
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
     factory_bot (6.4.2)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.2)
@@ -161,6 +171,9 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
+    fugit (1.9.0)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-apis-bigquery_v2 (0.60.0)
@@ -326,6 +339,7 @@ GEM
     public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.8)
     rack-oauth2 (2.2.0)
@@ -461,6 +475,10 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-cron (1.12.0)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     signet (0.18.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -550,6 +568,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bootsnap
   capybara
   clockwork
@@ -584,6 +603,7 @@ DEPENDENCIES
   sentry-ruby
   shoulda-matchers
   sidekiq (< 7)
+  sidekiq-cron
   solargraph
   solargraph-rails
   syntax_tree

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,10 +31,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def dsi_user_signed_in?
-    !!current_dsi_user
-  end
-
   def handle_expired_session!
     if session[:dsi_user_session_expiry].nil?
       redirect_to sign_out_path

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class SupportInterfaceController < ApplicationController
+    before_action :authorise_internal_user!
+
+    def authorise_internal_user!
+    end
+  end
+end
+

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,8 +1,13 @@
 module SupportInterface
   class SupportInterfaceController < ApplicationController
-    before_action :authorise_internal_user!
+    before_action :authorize_internal_user!
 
-    def authorise_internal_user!
+    def authorize_internal_user!
+      render "support_interface/not_authorised", status: :forbidden unless current_dsi_user &&
+        current_dsi_user.internal?
+    end
+
+    def not_authorised
     end
   end
 end

--- a/app/controllers/support_interface/uploads_controller.rb
+++ b/app/controllers/support_interface/uploads_controller.rb
@@ -1,5 +1,5 @@
 module SupportInterface
-  class UploadsController < ApplicationController
+  class UploadsController < SupportInterfaceController
     def new
       @upload_form = UploadForm.new
     end

--- a/app/jobs/trim_sessions_job.rb
+++ b/app/jobs/trim_sessions_job.rb
@@ -1,0 +1,8 @@
+require "rake"
+Rails.application.load_tasks
+
+class TrimSessionsJob < ApplicationJob
+  def perform
+    Rake::Task['db:sessions:trim'].invoke
+  end
+end

--- a/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
+++ b/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
@@ -28,7 +28,8 @@ module DfESignInApi
     end
 
     def authorised_role_codes
-      ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",")
+      ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",") <<
+        ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
     end
   end
 end

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -21,4 +21,12 @@ class DsiUser < ApplicationRecord
 
     dsi_user
   end
+
+  def internal?
+    current_session&.role_code == ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
+  end
+
+  def current_session
+    dsi_user_sessions.order(created_at: :desc).first
+  end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,7 +36,7 @@
         end
       end
 
-      if support_interface?
+      if current_dsi_user&.internal?
         header.with_navigation_item(href: "/support/features", text: "Features")
         header.with_navigation_item(href: "/support/uploads/new", text: "File upload")
       end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -28,11 +28,11 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(service_name: t("service.name")) do |header|
-      if request.path != not_authorised_path
+      if request.path != main_app.not_authorised_path
         if current_dsi_user
-          header.with_navigation_item(href: dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
+          header.with_navigation_item(href: main_app.dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
         else
-          header.with_navigation_item(href: sign_in_path, text: "Sign in")
+          header.with_navigation_item(href: main_app.sign_in_path, text: "Sign in")
         end
       end
 

--- a/app/views/support_interface/not_authorised.html.erb
+++ b/app/views/support_interface/not_authorised.html.erb
@@ -1,0 +1,4 @@
+<h1 class="govuk-heading-l">You cannot use the DfE Sign-in account for <%= session[:organisation_name] %> to perform this action</h1>
+<p class="govuk-body">
+  If you have access to another organisation in DfE Sign-in, you can <%= govuk_link_to("sign out and start again", main_app.sign_out_path(id_token_hint: session[:id_token])) %>.
+</p>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -12,3 +12,9 @@ shared:
     - upload_file_hash
     - created_at
     - updated_at
+  :sessions:
+    - id
+    - session_id
+    - data
+    - created_at
+    - updated_at

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,3 +1,4 @@
+parent_controller: "SupportInterface::SupportInterfaceController"
 feature_flags:
   service_open:
     author: Steve Laing

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, key: '_cbl_session'

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,3 @@
+trim_db_sessions:
+  cron: "0 4 * * *" # every day at 4am
+  class: "TrimSessionsJob"

--- a/db/migrate/20231208160940_add_sessions_table.rb
+++ b/db/migrate/20231208160940_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_084304) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_08_160940) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -65,6 +65,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_084304) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
 end

--- a/spec/factories/dsi_user_sessions.rb
+++ b/spec/factories/dsi_user_sessions.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :dsi_user_session do |f|
+  end
+end

--- a/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
+++ b/spec/lib/dfe_sign_in_api/get_user_access_to_service_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe DfESignInApi::GetUserAccessToService do
     let(:org_id) { "123" }
     let(:user_id) { "456" }
     let(:role_id) { "789" }
-    let(:role_code) { ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first }
+    let(:standard_role_code) { ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first }
+    let(:internal_role_code) { ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE") }
     let(:endpoint) do
       [
         ENV.fetch("DFE_SIGN_IN_API_BASE_URL"),
@@ -15,26 +16,30 @@ RSpec.describe DfESignInApi::GetUserAccessToService do
 
     subject { described_class.new(org_id:, user_id:).call }
 
-    context "when the user is authorised" do
-      before do
-        stub_request(:get, endpoint)
+    before do
+      stub_request(:get, endpoint)
         .to_return_json(
           status: 200,
           body: { "roles" => [{ "id" => role_id, "code" => role_code }] },
         )
+    end
+
+    context "when the user is authorised" do
+      context "with a standard role code" do
+        let(:role_code) { standard_role_code }
+
+        it { is_expected.to eq({ "id" => role_id, "code" => role_code }) }
       end
 
-      it { is_expected.to eq({ "id" => role_id, "code" => role_code }) }
+      context "with an internal role code" do
+        let(:role_code) { internal_role_code }
+
+        it { is_expected.to eq({ "id" => role_id, "code" => role_code }) }
+      end
     end
 
     context "when the user is not authorised" do
-      before do
-        stub_request(:get, endpoint)
-        .to_return_json(
-          status: 200,
-          body: { "roles" => [{ "id" => role_id, "code" => "Unauthorised_Role" }] },
-        )
-      end
+      let(:role_code) { "Unauthorised_Role" }
 
       it { is_expected.to be_nil }
     end

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -58,4 +58,42 @@ RSpec.describe DsiUser, type: :model do
       end
     end
   end
+
+  describe "#current_session" do
+    let(:dsi_user) { create(:dsi_user) }
+    let!(:expected_current_session) { create(:dsi_user_session, dsi_user:, created_at: 1.second.ago) }
+    let!(:dsi_user_sessions) do
+      [10.minutes.ago, 1.minute.ago].each do |created_at|
+        create(:dsi_user_session,dsi_user:, created_at:)
+      end
+    end
+
+    it "returns the latest session" do
+      expect(dsi_user.current_session).to eq expected_current_session
+    end
+  end
+
+  describe "#internal?" do
+    let(:dsi_user) { create(:dsi_user) }
+
+    context "when the user has the internal role in their current session" do
+      let!(:dsi_user_session) do
+        create(:dsi_user_session, dsi_user:, role_code: ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE"))
+      end
+
+      it "returns true" do
+        expect(dsi_user.internal?).to eq true
+      end
+    end
+
+    context "when the user does not have the internal role in their current session" do
+      let!(:dsi_user_session) do
+        create(:dsi_user_session, dsi_user:, role_code: "random role")
+      end
+
+      it "returns false" do
+        expect(dsi_user.internal?).to eq false
+      end
+    end
+  end
 end

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -1,12 +1,19 @@
 module AuthenticationSteps
   def when_i_sign_in_via_dsi(authorised: true)
-    given_dsi_auth_is_mocked(authorised:)
+    given_dsi_auth_is_mocked(authorised:, role_code:)
     when_i_visit_the_sign_in_page
     and_click_the_dsi_sign_in_button
   end
   alias_method :and_i_am_signed_in_via_dsi, :when_i_sign_in_via_dsi
 
-  def given_dsi_auth_is_mocked(authorised:)
+  def when_i_sign_in_as_an_internal_user_via_dsi
+    given_dsi_auth_is_mocked(authorised: true, role_code: internal_user_role_code )
+    when_i_visit_the_sign_in_page
+    and_click_the_dsi_sign_in_button
+  end
+  alias_method :and_i_am_signed_in_as_an_internal_user_via_dsi, :when_i_sign_in_as_an_internal_user_via_dsi
+
+  def given_dsi_auth_is_mocked(authorised:, role_code:)
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       {
         provider: "dfe",
@@ -63,6 +70,10 @@ module AuthenticationSteps
 
   def role_code
     ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",").first
+  end
+
+  def internal_user_role_code
+    ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
   end
 
   def when_i_visit_the_sign_in_page

--- a/spec/system/support_interface/support_user_uploads_a_csv_file_spec.rb
+++ b/spec/system/support_interface/support_user_uploads_a_csv_file_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Upload file", type: :system do
 
   scenario "Support user uploads a valid CSV file", test: :with_stubbed_auth do
     given_the_service_is_open
-    and_i_am_signed_in_via_dsi
+    and_i_am_signed_in_as_an_internal_user_via_dsi
     and_i_am_on_the_upload_page
     when_i_upload_a_valid_csv_file
     then_i_see_a_preview_of_the_data

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -36,12 +36,14 @@ RSpec.describe "DSI authentication", type: :system do
   def and_i_can_access_the_support_interface
     visit support_interface_root_path
     expect(page).to have_content("Features")
-    visit new_support_interface_upload_path
+    click_on "File upload"
     expect(page).to have_content("Upload records")
   end
 
   def and_i_cannot_access_the_support_interface
     not_authorised_message = "You cannot use the DfE Sign-in account for Test School to perform this action"
+    visit root_path
+    expect(page).not_to have_content("Features")
     visit support_interface_root_path
     expect(page).to have_content(not_authorised_message)
     visit new_support_interface_upload_path

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe "DSI authentication", type: :system do
     given_the_service_is_open
     when_i_sign_in_via_dsi
     then_i_am_signed_in
+    and_i_cannot_access_the_support_interface
+  end
+
+  scenario "Internal user signs in via DfE Sign In", test: :with_stubbed_auth do
+    given_the_service_is_open
+    when_i_sign_in_as_an_internal_user_via_dsi
+    then_i_am_signed_in
+    and_i_can_access_the_support_interface
   end
 
   private
@@ -23,5 +31,20 @@ RSpec.describe "DSI authentication", type: :system do
     end
     expect(DsiUser.count).to eq 1
     expect(DsiUserSession.count).to eq 1
+  end
+
+  def and_i_can_access_the_support_interface
+    visit support_interface_root_path
+    expect(page).to have_content("Features")
+    visit new_support_interface_upload_path
+    expect(page).to have_content("Upload records")
+  end
+
+  def and_i_cannot_access_the_support_interface
+    not_authorised_message = "You cannot use the DfE Sign-in account for Test School to perform this action"
+    visit support_interface_root_path
+    expect(page).to have_content(not_authorised_message)
+    visit new_support_interface_upload_path
+    expect(page).to have_content(not_authorised_message)
   end
 end


### PR DESCRIPTION
### Context

CBL has a support interface where we manage application config and upload additions to the data. This section of the service should only be available to users with the internal user role from DSI internal organisation.

### Changes proposed in this pull request

* switch to DB sessions. We're overflowing the cookie by putting the ID token in it from DSI. Doing it this way rather than storing the token on the dsi_user_session model means we can prune the old ones easily out of the database.
* Add an extra env var for internal user and add `DsiUser#internal?` to allow us to identify internal users throughout the service. We already store the role on the `DsiUserSession` model so I've just exposed the current one through the user
* Scope features and the upload stuff under `SupportInterface::SupportInterfaceController` and enforce the authorisation in there.
* Remove a bit of unused code
* Fix the path helper scoping in the support interface. This is currently causing errors in main.

### Guidance to review

I've used a different approach than we've used in CTR which has a completely separate set of auth code for support/internal users. This seemed a simpler approach and means the internal user can just access the service as well without a different login but happy to discuss if CTR is a better approach for other reasons.

Probably needs a bit of finessing of local env to move the role that DSI returns between the standard and internal env vars. The internal role should be able to access everything, a standard role only things outside of the SupportInterface scope and a role not in either shouldn't have any access.


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
