### PR TITLE
Add validations for missing date part attributes

### DIFF
--- a/app/validators/day_month_year_validator.rb
+++ b/app/validators/day_month_year_validator.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 class DayMonthYearValidator
-  def validate(record, attribute)
-    @record = record
+  attr_accessor :attribute, :record
 
-    return true unless all_present?
+  def validate(record, attribute)
+    self.attribute = attribute
+    self.record = record
+
+    validate_date_parts_presence
 
     unless valid?
       record.errors.add(attribute, :invalid)
@@ -49,5 +52,36 @@ class DayMonthYearValidator
 
   def date
     @date ||= Date.new(@record.year.to_i, @record.month.to_i, @record.day.to_i)
+  end
+
+  def validate_date_parts_presence
+    if record.day.blank? && record.month.blank?
+      record.errors.add(attribute, :missing_day_and_month)
+      return
+    end
+
+    if record.day.blank? && record.year.blank?
+      record.errors.add(attribute, :missing_day_and_year)
+      return
+    end
+
+    if record.month.blank? && record.year.blank?
+      record.errors.add(attribute, :missing_month_and_year)
+      return
+    end
+
+    if record.day.blank?
+      record.errors.add(attribute, :missing_day) 
+      return
+    end
+
+    if record.month.blank?
+      record.errors.add(attribute, :missing_month)
+      return
+    end
+
+    if record.year.blank?
+      record.errors.add(attribute, :missing_year)
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,12 @@ en:
               future: Date of birth must be in the past
               invalid: Date of birth must be a real date
               invalid_year: Year must include 4 numbers
+              missing_day: Date of birth must include a day
+              missing_month: Date of birth must include a month
+              missing_year: Date of birth must include a year
+              missing_day_and_month: Date of birth must include a day and month
+              missing_day_and_year: Date of birth must include a day and year
+              missing_month_and_year: Date of birth must include a month and year
               over_100: Date of birth cannot be more than 100 years ago
               under_16: Date of birth must be at least 16 years ago
         "support_interface/upload_form":

--- a/spec/validators/day_month_year_validator_spec.rb
+++ b/spec/validators/day_month_year_validator_spec.rb
@@ -96,24 +96,84 @@ RSpec.describe DayMonthYearValidator do
     context "when day is missing" do
       let(:attributes) { { day: nil, month: "6", year: "1990" } }
 
-      it "does not perform validation" do
-        expect(validatable).to be_valid
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_day")
       end
     end
 
     context "when month is missing" do
       let(:attributes) { { day: "15", month: nil, year: "1990" } }
 
-      it "does not perform validation" do
-        expect(validatable).to be_valid
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_month")
       end
     end
 
     context "when year is missing" do
       let(:attributes) { { day: "15", month: "6", year: nil } }
 
-      it "does not perform validation" do
-        expect(validatable).to be_valid
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_year")
+      end
+    end
+
+    context "when day and month are missing" do
+      let(:attributes) { { day: nil, month: nil, year: "1990" } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_day_and_month")
+      end
+    end
+
+    context "when day and year are missing" do
+      let(:attributes) { { day: nil, month: "6", year: nil } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_day_and_year")
+      end
+    end
+    
+    context "when month and year are missing" do
+      let(:attributes) { { day: "15", month: nil, year: nil } }
+
+      it "fails validation" do
+        expect(validatable).to be_invalid
+      end
+
+      it "adds an error message" do
+        validatable.valid?
+
+        expect(validatable.errors[:date_attribute].first).to include("missing_month_and_year")
       end
     end
   end


### PR DESCRIPTION
As part of a review on date field validations, we want to add errors
when a part of the date is missing to give better guidance to users.

### Link to Trello card

https://trello.com/c/XkGZCFr0/1428-update-date-field-error-messages-for-childrens-barred-list

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
