### PR TITLE
Add static pages

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
 class StaticController < ApplicationController
+  skip_before_action :authenticate_dsi_user!
+  skip_before_action :handle_expired_session!
+
   layout "two_thirds"
+
+  def accessibility
+  end
+
+  def cookies
+  end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -79,7 +79,7 @@
               <%= govuk_link_to("Cookies", "/cookies", class: "govuk-footer__link") %>
             </li>
             <li class="govuk-footer__inline-list-item">
-              <%= govuk_link_to("Privacy notice", "/privacy", class: "govuk-footer__link") %>
+              <%= govuk_link_to("Privacy notice", "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers", class: "govuk-footer__link") %>
             </li>
           </ul>
 

--- a/app/views/static/accessibility.html.md
+++ b/app/views/static/accessibility.html.md
@@ -1,0 +1,71 @@
+<% content_for :page_title, 'Accessibility statement' %>
+
+# Accessibility statement
+
+This statement applies to the <%= t('service.name') %> service.
+
+This service is run by the Department for Education. We want as many people as possible to be able to use it. You should be able to:
+
+- change colours, contrast levels and fonts
+- zoom in up to 300% without the text spilling off the screen
+- navigate most of the service using just a keyboard
+- navigate most of the service using speech recognition
+  software
+- listen to most of the service using a screen reader (including the most recent
+  versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the text in the service as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device
+easier to use if you have a disability.
+
+## How accessible this service is
+
+All parts of this service are fully accessible.
+
+## Reporting accessibility problems with this service
+
+We are always looking to improve the accessibility of this service.
+
+If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us:
+
+Email: <a href="mailto:<%=
+t('service.email') %>" class="govuk-link govuk-link--no-visited-state"><%=
+t('service.email') %></a>
+
+<a class="govuk-link" href="http://www.w3.org/WAI/users/inaccessible">Read tips on contacting organisations about inaccessible websites</a>
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing
+the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+Accessibility Regulations 2018 (the ‘accessibility regulations’).
+
+If you’re not happy with how we respond to your complaint, contact [the
+Equality Advisory and Support Service
+(EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this service’s accessibility
+
+The Department for Education is committed to making this service accessible, in
+accordance with the Public Sector Bodies (Websites and Mobile Applications)
+(No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This service is fully compliant with [the Web Content Accessibility Guidelines
+version 2.2 AA standard](https://www.w3.org/TR/WCAG22/).
+
+There may be accessibility issues we have not found yet. If you find any please contact us so we can continue to improve the services we provide.
+
+### Disproportionate burden
+
+Not applicable
+
+### Content not within scope of this accessibility statement
+
+Not applicable
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 12 June 2023.

--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
+
 class MarkdownTemplate
   def self.call(template, source)
+    source ||= template.source
+
+    # Rails >= 7.1 does not work with the Redcarpet markdown renderer.
+    # There is an argument mismatch where a string is expected but an OutputBuffer is provided.
+    # This is a workaround to convert the buffer to a string.
     erb_handler = ActionView::Template.registered_template_handler(:erb)
-    compiled_source = erb_handler.call(template, source)
+    compiled_source = ActionView::OutputBuffer.new( erb_handler.call( template, source ) )
+    compiled_source << '.to_s'
     "GovukMarkdown.render(begin;#{compiled_source};end).html_safe"
   end
 end


### PR DESCRIPTION
### Context

We should have content available on the service for Accessibility, Cookies and Privacy 
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds accessibility and cookies pages and links to GOVUK privacy for educators content.


### Accessibility
![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/5a2359c8-262b-4476-848b-fd1764f46833)

### Cookies
![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/afb95dda-e71b-4caa-b35d-eafbe62bee9f)


<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/OrxwuvEr/1434-cbl-static-pages
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
