### PR TITLE
Always return internal user role if present

### DIFF
--- a/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
+++ b/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
@@ -13,7 +13,8 @@ module DfESignInApi
       response = client.get(endpoint)
 
       if response.success? && response.body.key?("roles")
-        response.body["roles"].find { |role| authorised_role_codes.include?(role["code"]) }
+        response.body["roles"].find { |role| role["code"] == ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE") } ||
+          response.body["roles"].find { |role| authorised_role_codes.include?(role["code"]) }
       end
     end
 
@@ -28,8 +29,7 @@ module DfESignInApi
     end
 
     def authorised_role_codes
-      ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",") <<
-        ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
+      ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",")
     end
   end
 end


### PR DESCRIPTION
### Context

If a user reaches the authorisation check and has an internal user role **and** a normal user role we should always prefer the internal (ie support) user role over any others. This ensures they are authorised with maximum permissions.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Ensure we return (and store in session) the internal user role if present in the service authorisation check response.
 
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I've refactored the system spec helper, hopefully for the better :)
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/zEBi7Chg/1505-handle-multiple-dsi-roles
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
