### PR TITLE
Handle missing name fields in the CSV upload

### DIFF
--- a/app/services/create_childrens_barred_list_entries.rb
+++ b/app/services/create_childrens_barred_list_entries.rb
@@ -32,6 +32,8 @@ class CreateChildrensBarredListEntries
   end
 
   def format_names(names)
+    return if names.blank?
+
     names.strip!
     names.gsub!(TITLES_REGEX, "")
     names.downcase.split(" ").map(&:capitalize).join(" ")

--- a/spec/services/create_childrens_barred_list_entries_spec.rb
+++ b/spec/services/create_childrens_barred_list_entries_spec.rb
@@ -36,4 +36,40 @@ RSpec.describe CreateChildrensBarredListEntries do
     expect(service.upload_file_hash).not_to be_nil
     expect(service.upload_file_hash).to eq(Digest::SHA256.hexdigest(csv_data))
   end
+
+  context 'when a row is blank' do
+    let(:csv_data) do
+      [
+        [nil, nil, nil, nil, nil].join(",")
+      ].join("\n")
+    end
+
+    it "does not create a new ChildrensBarredListEntry" do
+      expect { service.call }.not_to(change { ChildrensBarredListEntry.count })
+    end
+  end
+
+  context 'when a row has a missing last name field' do
+    let(:csv_data) do
+      [
+        ["12567", nil, "DR. JOHN JAMES ", "01/02/1990", "AB123456C"].join(",")
+      ].join("\n")
+    end
+
+    it "does not create a new ChildrensBarredListEntry" do
+      expect { service.call }.not_to(change { ChildrensBarredListEntry.count })
+    end
+  end
+
+  context 'when a row has a missing first name field' do
+    let(:csv_data) do
+      [
+        ["12567", "SMITH ", nil, "01/02/1990", "AB123456C"].join(",")
+      ].join("\n")
+    end
+
+    it "does not create a new ChildrensBarredListEntry" do
+      expect { service.call }.not_to(change { ChildrensBarredListEntry.count })
+    end
+  end
 end


### PR DESCRIPTION
There is a scenario where someone uploads a CSV that has a blank name.

Currently, our formatting code doesn't handle this and throws an error.

I opted to add a guard clause to the formatting method to avoid the
error.

This means that the attempt to create the entry will also fail but won't
throw an error, due to the validation on the presence of the name
fields.

Potentially, this could cause confusion, as a row with a missing first
name will simply not show in the preview of the upload.

### Link to Trello card

https://trello.com/c/RSBXEDOM/1608-handle-invalid-csv-format

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
