### PR TITLE
Add national insurance number validation to entries

### DIFF
--- a/app/models/childrens_barred_list_entry.rb
+++ b/app/models/childrens_barred_list_entry.rb
@@ -6,6 +6,10 @@ class ChildrensBarredListEntry < ApplicationRecord
               scope: %i[first_names date_of_birth]
             }
   validates :date_of_birth, presence: true
+  validates :national_insurance_number,
+    format: {
+      with: /\A[a-z]{2}[0-9]{6}[a-d]{1}\Z/i
+    }, if: -> { national_insurance_number.present? }
 
   def self.search(last_name:, date_of_birth:)
     where(

--- a/spec/models/childrens_barred_list_entry_spec.rb
+++ b/spec/models/childrens_barred_list_entry_spec.rb
@@ -5,6 +5,21 @@ RSpec.describe ChildrensBarredListEntry, type: :model do
   it { is_expected.to validate_presence_of(:last_name) }
   it { is_expected.to validate_presence_of(:date_of_birth) }
 
+  describe "validations" do
+    it "is valid with a valid national_insurance_number format" do
+      entry = build(:childrens_barred_list_entry)
+      entry.national_insurance_number = "AB123456D"
+      expect(entry).to be_valid
+    end
+
+    it "is invalid with an invalid national_insurance_number format" do
+      entry = build(:childrens_barred_list_entry)
+      entry.national_insurance_number = "AB6D"
+      expect(entry).not_to be_valid
+      expect(entry.errors.full_messages).to include("National insurance number is invalid")
+    end
+  end
+
   describe "#self.search" do
     let(:record) { create(:childrens_barred_list_entry) }
 


### PR DESCRIPTION
### Context
We’re not validating for NI number format.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
We only allow valid NI numbers — two letters, six numbers and a letter.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/MCr35BKn/1607-ni-number-format-validation
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
