### PR TITLE
Check organisation status in DSI

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -37,8 +37,10 @@ class OmniauthCallbacksController < ApplicationController
   end
 
   def role
+    return if organisation_ids.exclude?(authenticated_organisation_id)
+
     @role ||= DfESignInApi::GetUserAccessToService.new(
-      org_id: auth.extra.raw_info.organisation.id,
+      org_id: authenticated_organisation_id,
       user_id: auth.uid,
     ).call
   end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -42,4 +42,18 @@ class OmniauthCallbacksController < ApplicationController
       user_id: auth.uid,
     ).call
   end
+
+  def organisations
+    @organisations ||= DfESignInApi::GetOrganisationsForUser.new(
+      user_id: auth.uid,
+    ).call
+  end
+
+  def organisation_ids
+    organisations&.map { |org| org["id"] }
+  end
+
+  def authenticated_organisation_id
+    auth.extra.raw_info.organisation.id
+  end
 end

--- a/app/lib/dfe_sign_in_api/get_organisations_for_user.rb
+++ b/app/lib/dfe_sign_in_api/get_organisations_for_user.rb
@@ -1,0 +1,27 @@
+module DfESignInApi
+  class GetOrganisationsForUser
+    include Client
+
+    attr_reader :user_id
+
+    def initialize(user_id:)
+      @user_id = user_id
+    end
+
+    def call
+      response = client.get(endpoint)
+
+      if response.success? && response.body.any?
+        response.body.reject { |org| org["status"]["name"] == "Closed" }
+      else
+        []
+      end
+    end
+
+    private
+
+    def endpoint
+      "/users/#{user_id}/organisations"
+    end
+  end
+end

--- a/spec/lib/dfe_sign_in_api/get_organisations_for_user_spec.rb
+++ b/spec/lib/dfe_sign_in_api/get_organisations_for_user_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe DfESignInApi::GetOrganisationsForUser do
+  describe "#call" do
+    let(:user_id) { "456" }
+    let(:endpoint) do
+      [
+        ENV.fetch("DFE_SIGN_IN_API_BASE_URL"),
+        "/users/#{user_id}/organisations"
+      ].join
+    end
+
+    let(:open_org) do
+      {
+        "id" => "org-y",
+        "name" => "Organisation Y",
+        "status" => { "id" => 1, "name" => "Open" },
+      }
+    end
+    let(:closed_org) do
+      {
+        "id" => "org-x",
+        "name" => "Organisation X",
+        "status" => { "id" => 0, "name" => "Closed" },
+      }
+    end
+    let(:body) do
+      [open_org, closed_org]
+    end
+
+    subject { described_class.new(user_id:).call }
+
+    before do
+      stub_request(:get, endpoint)
+        .to_return_json(
+          status: 200,
+          body:,
+      )
+    end
+
+    context "when the user belongs to an open organisation" do
+      it { is_expected.to eq([open_org]) }
+    end
+
+    context "when the user only belongs to a closed organisation" do
+      let(:body) { [closed_org] }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context "when the user doesn't belong to any organisations" do
+      let(:body) { [] }
+
+      it { is_expected.to eq([]) }
+    end
+  end
+end

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -1,6 +1,6 @@
 module AuthenticationSteps
-  def when_i_sign_in_via_dsi(authorised: true)
-    given_dsi_auth_is_mocked(authorised:)
+  def when_i_sign_in_via_dsi(authorised: true, orgs: [organisation])
+    given_dsi_auth_is_mocked(authorised:, orgs:)
     when_i_visit_the_sign_in_page
     and_click_the_dsi_sign_in_button
   end
@@ -13,7 +13,7 @@ module AuthenticationSteps
   end
   alias_method :and_i_am_signed_in_as_an_internal_user_via_dsi, :when_i_sign_in_as_an_internal_user_via_dsi
 
-  def given_dsi_auth_is_mocked(authorised: true, internal: false)
+  def given_dsi_auth_is_mocked(authorised: true, internal: false, orgs: [organisation])
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       {
         provider: "dfe",
@@ -35,6 +35,13 @@ module AuthenticationSteps
           }
         }
       }
+    )
+
+    stub_request(
+      :get, organisations_endpoint
+    ).to_return_json(
+      status: 200,
+      body: orgs,
     )
 
     stub_request(
@@ -92,5 +99,17 @@ module AuthenticationSteps
 
   def and_click_the_dsi_sign_in_button
     click_button "Sign in"
+  end
+
+  def organisations_endpoint
+    "#{ENV.fetch("DFE_SIGN_IN_API_BASE_URL")}/users/123456/organisations"
+  end
+
+  def organisation(status: "Open")
+    {
+      "id" => org_id,
+      "name" => "Test School",
+      "status" => { "id" => 1, "name" => status },
+    }
   end
 end

--- a/spec/system/user_belonging_to_closed_org_signs_in_spec.rb
+++ b/spec/system/user_belonging_to_closed_org_signs_in_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DSI authentication", type: :system do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  scenario "User belonging to closed organisation signs in via DfE Sign In", test: :with_stubbed_auth do
+    given_the_service_is_open
+    when_i_sign_in_via_dsi(orgs: [organisation(status: "Closed")])
+    then_i_am_not_authorised
+  end
+
+  private
+
+  def then_i_am_not_authorised
+    expect(page.status_code).to eq 401
+    expect(page).to have_content(
+      "You cannot use the DfE Sign-in account for Test School to check the children's barred list"
+    )
+    expect(page).to have_link("sign out and start again", href: "/auth/dfe/sign-out?id_token_hint=abc123")
+
+    within(".govuk-header__content") do
+      expect(page).not_to have_link("Sign in")
+      expect(page).not_to have_link("Sign out")
+    end
+  end
+end


### PR DESCRIPTION
### Context

User access to the application are checked via roles which are returned for an organisation ID returned in the OAuth response.
We don't currently check that the organisation is "Open", ie. a current valid org. 
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a DSI API call to ensure the org ID from the OAuth response belongs to a valid open organisation.
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

We can only get organisational status from [a separate DSI API call](https://github.com/DFE-Digital/check-childrens-barred-list/pull/212/files#diff-0f99d81511d17dcd32f5857adf7f1076108302cd0a91ee61d66727ff4f1a1284R49) so there is a performance penalty introducing this check. 

Do we need an error message particular to closed org authorisation failures?

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/HK5tX73P/1507-spike-check-organisation-status-in-dsi

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
