### PR TITLE
Make error message output html safe

### DIFF
--- a/app/views/support_interface/uploads/_entry_table.html.erb
+++ b/app/views/support_interface/uploads/_entry_table.html.erb
@@ -20,7 +20,7 @@
       <td class="govuk-table__cell"><%= Date.parse(entry.date_of_birth.to_s).to_fs(:dob) if entry.date_of_birth.present? %></td>
       <td class="govuk-table__cell"><%= entry.trn %></td>
       <% if show_errors %>
-        <td class="govuk-table__cell govuk-error-message govuk-!-margin-bottom-0"><%= entry.failure_messages.join("<br/>") %></td>
+        <td class="govuk-table__cell govuk-error-message govuk-!-margin-bottom-0"><%== entry.failure_messages.join("<br/>") %></td>
       <% else %>
         <td class="govuk-table__cell"><%= entry.national_insurance_number %></td>
       <% end %>


### PR DESCRIPTION
### Context

The `<br/>` html tag used to format error messages was rendering as code.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Make error message output html safe.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
