### PR TITLE
Update encryption docs

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -5,15 +5,7 @@ The application uses [ActiveRecord Encryption](https://guides.rubyonrails.org/ac
 Application-level encryption ensures that we reduce the risk of leaking PII information should
 the database ever be compromised.
 
-## Encryption keys
-
-Rails encrypts data using a key that is stored outside of version control. In deployed environments
-we use the `RAILS_MASTER_KEY` environment variable to pass the key to the application.
-
-For local development, the key is stored in `config/master.key`. This file is not encrypted, so it
-should be kept secret.
-
-## Rails DB encryption configuration
+## Rails DB encryption keys configuration
 
 **Note:** We do not store db encryption keys in Rails credentials, as these cannot be easily set per hosting environment.
 
@@ -25,7 +17,9 @@ config.active_record_encryption.deterministic_key
 config.active_record_encryption.key_derivation_salt
 ```
 
-The application reads these from environment variables populated either locally from `.env.local` or from the appropriate keyvault secret.
+The application reads these from environment variables populated either locally from dotenv files, or from the appropriate keyvault secrets.
+
+## Generate ActiveRecord database encryption secrets
 
 To generate or regenerate these configuration values run:
 
@@ -33,4 +27,4 @@ To generate or regenerate these configuration values run:
 
 Paste the resulting output to either your `.env.local` _and_ `.env.test.local` files.
 
-If you are generating application secrets in Azure, amend this output to a valid YAML format for the appropriate keyvault.
+If you are generating application secrets in Azure, amend this output to a valid YAML format and save in the appropriate keyvault.


### PR DESCRIPTION
### Context

Rails master key is not relevant to how we generate and store AR encryption secrets. ie. we don't use Rails secrets to store these values. We use dotenv files or Azure keyvaults depending on the environment.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Update encryption docs.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
