### PR TITLE
Add column count validation

### DIFF
--- a/app/models/childrens_barred_list_entry.rb
+++ b/app/models/childrens_barred_list_entry.rb
@@ -2,6 +2,9 @@ class ChildrensBarredListEntry < ApplicationRecord
   encrypts :date_of_birth, :first_names, :last_name, :searchable_last_name, deterministic: true
   encrypts :trn, :national_insurance_number
 
+  REQUIRED_SOURCE_COLUMN_COUNT = 6
+  attr_accessor :source_column_count
+
   validates :first_names, presence: true
   validates :last_name,
             presence: true,
@@ -11,6 +14,7 @@ class ChildrensBarredListEntry < ApplicationRecord
     format: {
       with: /\A[a-z]{2}[0-9]{6}[a-d]{1}\Z/i
     }, if: -> { national_insurance_number.present? }
+  validate :source_column_count_is_correct
 
   before_save :populate_searchable_last_name
 
@@ -36,5 +40,12 @@ class ChildrensBarredListEntry < ApplicationRecord
 
   def failure_messages
     errors.full_messages
+  end
+
+  def source_column_count_is_correct
+    return if source_column_count.nil?
+    return if source_column_count == REQUIRED_SOURCE_COLUMN_COUNT
+
+    errors.add(:source_column_count, :invalid, required_count: REQUIRED_SOURCE_COLUMN_COUNT)
   end
 end

--- a/app/services/create_childrens_barred_list_entries.rb
+++ b/app/services/create_childrens_barred_list_entries.rb
@@ -15,6 +15,7 @@ class CreateChildrensBarredListEntries
     CSV
       .parse(@raw_data, encoding: "ISO8859-1:utf-8")
       .each do |row|
+        source_column_count = row.count
         entry = ChildrensBarredListEntry.create(
           trn: pad_trn(row[0]),
           last_name: format_names(row[1]),
@@ -22,6 +23,7 @@ class CreateChildrensBarredListEntries
           date_of_birth: format_date_of_birth(row[3]),
           national_insurance_number: row[4],
           upload_file_hash:,
+          source_column_count:
         )
 
         @failed_entries << entry unless entry.persisted?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
           attributes:
             last_name:
               taken: with same first names and date of birth already exists
+            source_column_count:
+              invalid: The uploaded file must have %{required_count} columns
         feedback:
           attributes:
             satisfaction_rating:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,12 @@ en:
               blank: Select a file
               invalid_csv: The selected file must be a CSV
   activerecord:
+    models:
+      childrens_barred_list_entry: Children’s Barred List entry
+      feedback: Feedback
+    attributes:
+      childrens_barred_list_entry:
+        source_column_count: The uploaded file
     errors:
       models:
         childrens_barred_list_entry:
@@ -37,7 +43,7 @@ en:
             last_name:
               taken: with same first names and date of birth already exists
             source_column_count:
-              invalid: The uploaded file must have %{required_count} columns
+              invalid: must have %{required_count} columns
         feedback:
           attributes:
             satisfaction_rating:

--- a/spec/fixtures/example-incorrect-columns.csv
+++ b/spec/fixtures/example-incorrect-columns.csv
@@ -1,0 +1,4 @@
+Darby,James,10/11/1979,,N
+Jones,Tim,01/12/2001,,N
+Clongbong,Joe,07/06/1989,,N
+Kramer,Richie,18/09/1982,,N

--- a/spec/forms/support_interface/upload_form_spec.rb
+++ b/spec/forms/support_interface/upload_form_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe SupportInterface::UploadForm, type: :model do
     context "when the form is valid" do
       let(:csv_data) do
         [
-          ["12567", "Smith", "John James", "01/02/1990", "AB123456C"].join(","),
-          ["1234568", "Smith", "Jane Jemima", "07/05/1980", "AB123456D"].join(
+          ["12567", "Smith", "John James", "01/02/1990", "AB123456C", "N"].join(","),
+          ["1234568", "Smith", "Jane Jemima", "07/05/1980", "AB123456D", "N"].join(
             ","
           )
         ].join("\n")

--- a/spec/models/childrens_barred_list_entry_spec.rb
+++ b/spec/models/childrens_barred_list_entry_spec.rb
@@ -18,6 +18,31 @@ RSpec.describe ChildrensBarredListEntry, type: :model do
       expect(entry).not_to be_valid
       expect(entry.errors.full_messages).to include("National insurance number is invalid")
     end
+
+    describe "source_column_count" do
+      let(:params) { attributes_for(:childrens_barred_list_entry) }
+      subject { described_class.new(params) }
+
+      context "when not passed" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when passed" do
+        let(:params) { super().merge(source_column_count:) }
+
+        context "when it is REQUIRED_SOURCE_COLUMN_COUNT" do
+          let(:source_column_count) { ChildrensBarredListEntry::REQUIRED_SOURCE_COLUMN_COUNT }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when it is not REQUIRED_SOURCE_COLUMN_COUNT" do
+          let(:source_column_count) { ChildrensBarredListEntry::REQUIRED_SOURCE_COLUMN_COUNT - 1 }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
   end
 
   describe "#self.search" do

--- a/spec/services/create_childrens_barred_list_entries_spec.rb
+++ b/spec/services/create_childrens_barred_list_entries_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe CreateChildrensBarredListEntries do
   let(:csv_data) do
     [
-      ["12567", "SMITH ", "DR. JOHN JAMES ", "01/02/1990", "AB123456C"].join(","),
-      ["1234568", " jones ", " mrs jane jemima", "07/05/1980", "AB123456D"].join(",")
+      ["12567", "SMITH ", "DR. JOHN JAMES ", "01/02/1990", "AB123456C, N"].join(","),
+      ["1234568", " jones ", " mrs jane jemima", "07/05/1980", "AB123456D, N"].join(",")
     ].join("\n")
   end
 
@@ -78,7 +78,7 @@ RSpec.describe CreateChildrensBarredListEntries do
   context "when a row contains non-UTF-8 characters" do
     let(:csv_data) do
       [
-        ["12567", "Sánchezera-blobbá", "Angélina", "01/11/1990", "AB123456C"].join(","),
+        ["12567", "Sánchezera-blobbá", "Angélina", "01/11/1990", "AB123456C", "N"].join(","),
       ].join("\n").encode("ISO-8859-1")
     end
 


### PR DESCRIPTION
### Context

Excel annoyingly drops the first column from a CSV export if the column has no entries. Testers have fallen foul of this and created records with the data in incorrect columns and validation messages are then a bit unhelpful. 

### Changes proposed in this pull request

Validate the column count in each row to enable us to provide a more helpful error message when this happens.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
