### PR TITLE
Protect PII in CBL logging and analytics web requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,4 +42,22 @@ class ApplicationController < ActionController::Base
       redirect_to sign_out_path
     end
   end
+
+  def trigger_request_event
+    return unless DfE::Analytics.enabled?
+
+    request_event =
+      DfE::Analytics::FilteredRequestEvent
+        .new
+        .with_type("web_request")
+        .with_request_details(request)
+        .with_response_details(response)
+        .with_request_uuid(RequestLocals.fetch(:dfe_analytics_request_id))
+        .with_data(session_id: session[:session_id])
+
+    request_event.with_user(current_user) if respond_to?(:current_user, true)
+    request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
+
+    DfE::Analytics::SendEvents.do([request_event.as_json])
+  end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,4 +13,12 @@ Rails.application.config.filter_parameters += %i[
   certificate
   otp
   ssn
+  email
+  first_names
+  last_name
+  date_of_birth
+  trn
+  national_insurance_number
+  organisation_name
+  role_code
 ]

--- a/lib/dfe/analytics/filtered_request_event.rb
+++ b/lib/dfe/analytics/filtered_request_event.rb
@@ -1,0 +1,24 @@
+module DfE
+  module Analytics
+    class FilteredRequestEvent < Event
+      def with_request_details(rack_request)
+        @event_hash.merge!(
+          request_uuid: rack_request.uuid,
+          request_user_agent: ensure_utf8(rack_request.user_agent),
+          request_method: rack_request.method,
+          request_path: ensure_utf8(rack_request.path),
+          request_query: hash_to_kv_pairs(
+            request_query_filter.filter(Rack::Utils.parse_query(rack_request.query_string))),
+          request_referer: ensure_utf8(rack_request.referer),
+          anonymised_user_agent_and_ip: anonymised_user_agent_and_ip(rack_request)
+        )
+
+        self
+      end
+
+      def request_query_filter
+        ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      end
+    end
+  end
+end

--- a/spec/lib/dfe/analytics/filtered_request_event_spec.rb
+++ b/spec/lib/dfe/analytics/filtered_request_event_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "dfe/analytics/filtered_request_event"
+
+RSpec.describe DfE::Analytics::FilteredRequestEvent do
+  describe "#with_request_details" do
+    it "filters the request query according to Rails config" do
+      allow(Rails.application.config).to receive(:filter_parameters).and_return([:date, :name])
+
+      rack_request = double(
+        Rack::Request,
+        uuid: "123",
+        user_agent: "foo",
+        method: "GET",
+        path: "/bar",
+        query_string: "foo=bar&search[name]=bar]&search[date(3i)]=10&search[date(2i)]=10&search[date(1i)]=2000",
+        referer: "http://example.com",
+        remote_ip: "1.3.22.21",
+      )
+
+      event = described_class.new.with_request_details(rack_request)
+
+      expect(event.as_json).to include(
+        "request_uuid" => "123",
+        "request_user_agent" => "foo",
+        "request_method" => "GET",
+        "request_path" => "/bar",
+        "request_query" => [
+          {"key"=>"foo", "value"=>["bar"]},
+          {"key"=>"search[name]", "value"=>["[FILTERED]"]},
+          {"key"=>"search[date(3i)]", "value"=>["[FILTERED]"]},
+          {"key"=>"search[date(2i)]", "value"=>["[FILTERED]"]},
+          {"key"=>"search[date(1i)]", "value"=>["[FILTERED]"]},
+        ],
+        "request_referer" => "http://example.com",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

We’re currently passing the search terms as query string parameters, we should ensure this doesn't lead to any PII leaks.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

- Update filter parameter logging config to include names of sensitive db fields
- Add DfE Analytics web request filtering of sensitive fields in query strings

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/rNmbNx7Z/222-protect-pii-in-the-cbl-search-url
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
