### PR TITLE
Update terraform config

### DIFF
--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -9,8 +9,9 @@
   "key_vault_app_secret_name": "CCBL-APP-SECRETS-PRODUCTION",
   "key_vault_infra_secret_name": "CCBL-INFRA-SECRETS-PRODUCTION",
   "enable_monitoring": true,
+  "external_url": "https://check-the-childrens-barred-list.education.gov.uk",
   "probe_path": "/healthcheck",
-  "statuscake_contact_groups": [249142],
+  "statuscake_contact_groups": [288912],
   "startup_command": [
     "/bin/sh",
     "-c",


### PR DESCRIPTION
### Context

We use Statuscake for uptime alerting and SSL expiry checking but both haven't seemed to be working. It does look to be setup but is alerting the wrong group and possibly not working at all on SSL as the URL variable was null.

### Changes proposed in this pull request

* Change the alert group to one with a current slack channel
* Add the SSL check url to enable SSL certificate monitoring


### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
