### PR TITLE
Fix loading of DfE::Analytics::FilteredRequestEvent

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require "dfe/analytics/filtered_request_event"
+
 class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)

--- a/spec/lib/dfe/analytics/filtered_request_event_spec.rb
+++ b/spec/lib/dfe/analytics/filtered_request_event_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "dfe/analytics/filtered_request_event"
 
 RSpec.describe DfE::Analytics::FilteredRequestEvent do
   describe "#with_request_details" do


### PR DESCRIPTION
### Context

We're seeing the error `NameError (uninitialized constant DfE::Analytics::FilteredRequestEvent)` across deployed environments.
Introduced in https://github.com/DFE-Digital/check-childrens-barred-list/pull/234

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Require `DfE::Analytics::FilteredRequestEvent` in `ApplicationController`

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
