### PR TITLE
Add hosting environment name to Sentry initializer

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -16,6 +16,8 @@ end
 Sentry.init do |config|
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
+  config.environment = HostingEnvironment.environment_name
+
   filter =
     ActiveSupport::ParameterFilter.new(
       Rails.application.config.filter_parameters


### PR DESCRIPTION
### Context

We're not seeing Sentry errors in test or production.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Ensure we pass Sentry the correct hosting environment name.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/oRkgYgQc/1795-sentry-production-environment-setup
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
