### PR TITLE
Fix path helpers in support interface controller

### DIFF
--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,5 +1,6 @@
 module SupportInterface
   class SupportInterfaceController < ApplicationController
+    skip_before_action :authenticate_dsi_user!
     before_action :authorize_internal_user!
 
     def authorize_internal_user!
@@ -8,6 +9,20 @@ module SupportInterface
     end
 
     def not_authorised
+    end
+
+    private
+
+    def handle_expired_session!
+      if session[:dsi_user_session_expiry].nil?
+        redirect_to main_app.sign_out_path
+        return
+      end
+
+      if Time.zone.at(session[:dsi_user_session_expiry]).past?
+        flash[:warning] = "Your session has expired. Please sign in again."
+        redirect_to main_app.sign_out_path
+      end
     end
   end
 end


### PR DESCRIPTION


### Context
The DSI-related before actions in this controller were erroring when trying to access the Features section. This is because feature flags are implemented via an engine and the engine code wasn't able to resolve the path helpers in the main app.

<!-- Why are you making this change? -->

### Changes proposed in this pull request
Prefixing the path helpers with `main_app` addresses this.

Rather than use the shared before action in ApplicationController, we instead:

- have the support interface controller skip `authenticate_dsi_user!`, as it does its own check for an internal DSI user anyway
- implement a locally defined `handle_expired_session!`

More work is needed here to refine the support user UX, but this fixes the issue for the time being.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
