### PR TITLE
Configure exceptions app to use routes for errors controller

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module CheckTheChildrensBarredList
     config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
     config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
     config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
+
+    config.exceptions_app = self.routes # rubocop:disable Style/RedundantSelf
   end
 end


### PR DESCRIPTION
### Context

Error pages are not currently rendering, the response status is correct though.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Configure exceptions app to use routes for errors controller. See https://github.com/DFE-Digital/access-your-teaching-qualifications/blob/b08144768992a078dff10cecfb9c4cf1f894376f/config/application.rb#L55 for how we do this elsewhere.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/ePmS0RKY/1796-error-pages
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
