### PR TITLE
Fix make tasks where cluster config is required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,14 +168,14 @@ action-group-resources: set-azure-account # make production action-group-resourc
 	az group create -l uksouth -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --tags "Product=Database of Qualified Teachers" "Environment=${DEPLOY_ENV}" "Service Offering=Database of Qualified Teachers"
 	az monitor action-group create -n ${AZURE_RESOURCE_PREFIX}-check-childrens-barred-list -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --action email ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-email ${ACTION_GROUP_EMAIL}
 
-console: get-cluster-credentials
+console: read-cluster-config get-cluster-credentials
 	$(if $(APP_NAME), $(eval export APP_ID=$(APP_NAME)) , $(eval export APP_ID=$(CONFIG_LONG)))
 	kubectl -n ${NAMESPACE} exec -ti --tty deployment/check-childrens-barred-list-${APP_ID} -- /bin/sh -c "cd /app && /usr/local/bin/bundle exec rails c"
 
-logs: get-cluster-credentials
+logs: read-cluster-config get-cluster-credentials
 	$(if $(APP_NAME), $(eval export APP_ID=$(APP_NAME)) , $(eval export APP_ID=$(CONFIG_LONG)))
 	kubectl -n ${NAMESPACE} logs -l app=check-childrens-barred-list-${APP_ID} --tail=-1 --timestamps=true
 
-ssh: get-cluster-credentials
+ssh: read-cluster-config get-cluster-credentials
 	$(if $(APP_NAME), $(eval export APP_ID=$(APP_NAME)) , $(eval export APP_ID=$(CONFIG_LONG)))
 	kubectl -n ${NAMESPACE} exec -ti --tty deployment/check-childrens-barred-list-${APP_ID} -- /bin/sh


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/check-childrens-barred-list/pull/232 introduced some changes which broke the `console`, `logs` and `ssh` make tasks. These require the cluster config to be loaded so that namespaces and deployment names can be set.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Add `read-cluster-config` target to each of the broken jobs.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
