### PR TITLE
Add BQ table check job

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -3,6 +3,7 @@ require "hosting_environment"
 DfE::Analytics.configure do |config|
   config.queue = :analytics
   config.environment = HostingEnvironment.environment_name
+  config.entity_table_checks_enabled = true
 
   config.enable_analytics =
     proc do

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,7 @@
 trim_db_sessions:
   cron: "0 4 * * *" # every day at 4am
   class: "TrimSessionsJob"
+send_entity_table_check_data:
+  cron: "30 0 * * *" # Every day at 00:30.
+  class: "DfE::Analytics::EntityTableCheckJob"
+  queue: analytics


### PR DESCRIPTION
### Context

The data insights team have asked if we can add a check to our services to verify the data that we’re holding in BigQuery. The check periodically sends table row counts that can be checked against the big query data and runs as a scheduled job.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Add dfe-analytics config and schedule appropriate job to check tables.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/fVu2pkoU/1820-add-bigquery-table-check

<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
