### PR TITLE
Set up www redirect for production

### DIFF
--- a/terraform/custom_domains/environment_domains/config/ccbl_preproduction.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_preproduction.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "enable_alerting": false,
   "hosted_zone": {
     "check-the-childrens-barred-list.education.gov.uk": {
       "front_door_name": "s189p01-ccbl-edu-domains-fd",
@@ -8,7 +7,6 @@
       "cached_paths": ["/assets/*"],
       "environment_short": "pp",
       "origin_hostname": "check-childrens-barred-list-preproduction.test.teacherservices.cloud",
-      "null_host_header": true,
       "cnames": {}
     }
   }

--- a/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
@@ -4,12 +4,18 @@
     "check-the-childrens-barred-list.education.gov.uk": {
       "front_door_name": "s189p01-ccbl-edu-domains-fd",
       "resource_group_name": "s189p01-ccbldomains-rg",
-      "domains": ["apex"],
+      "domains": ["apex", "www"],
       "cached_paths": ["/assets/*"],
       "environment_short": "pd",
       "origin_hostname": "check-childrens-barred-list-production.teacherservices.cloud",
       "null_host_header": true,
-      "cnames": {}
+      "cnames": {},
+      "redirect_rules": [
+        {
+          "from-domain": "www",
+          "to-domain": "check-the-childrens-barred-list.education.gov.uk"
+        }
+      ]
     }
   }
 }

--- a/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "enable_alerting": false,
   "hosted_zone": {
     "check-the-childrens-barred-list.education.gov.uk": {
       "front_door_name": "s189p01-ccbl-edu-domains-fd",
@@ -8,7 +7,6 @@
       "cached_paths": ["/assets/*"],
       "environment_short": "pd",
       "origin_hostname": "check-childrens-barred-list-production.teacherservices.cloud",
-      "null_host_header": true,
       "cnames": {},
       "redirect_rules": [
         {

--- a/terraform/custom_domains/environment_domains/config/ccbl_test.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_test.tfvars.json
@@ -1,5 +1,4 @@
 {
-  "enable_alerting": false,
   "hosted_zone": {
     "check-the-childrens-barred-list.education.gov.uk": {
       "front_door_name": "s189p01-ccbl-edu-domains-fd",
@@ -8,7 +7,6 @@
       "cached_paths": ["/assets/*"],
       "environment_short": "test",
       "origin_hostname": "check-childrens-barred-list-test.test.teacherservices.cloud",
-      "null_host_header": true,
       "cnames": {}
     }
   }

--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -10,6 +10,7 @@ module "domains" {
   host_name             = each.value.origin_hostname
   null_host_header      = try(each.value.null_host_header, false)
   cached_paths          = try(each.value.cached_paths, [])
+  redirect_rules        = try(each.value.redirect_rules, [])
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -8,9 +8,9 @@ module "domains" {
   domains               = each.value.domains
   environment           = each.value.environment_short
   host_name             = each.value.origin_hostname
-  null_host_header      = try(each.value.null_host_header, false)
+  null_host_header      = true
   cached_paths          = try(each.value.cached_paths, [])
-  redirect_rules        = try(each.value.redirect_rules, [])
+  redirect_rules        = try(each.value.redirect_rules, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.


### PR DESCRIPTION
### Context

There has been request to redirect www.check-the-childrens-barred-list.education.gov.uk to check-the-childrens-barred-list.education.gov.uk 

### Changes proposed in this pull request

- Add "www" to the Prod config 

- Redirect "www" to "check-the-childrens-barred-list.education.gov.uk"



### Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/yzU6345V/1627-setup-a-redirect-for-https-wwwcheck-a-teachers-recordeducationgovuk)

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
