### PR TITLE
Update .tool-versions azure-cli -> 2.57.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-azure-cli 2.48.1
+azure-cli 2.57.0
 nodejs 19.6.0
 postgres 13.5
 ruby 3.3.0


### PR DESCRIPTION
### Context

We use azure-cli in the make commands. It's out of date.

### Changes proposed in this pull request

Update it. 