### PR TITLE
Notify Slack when deploys fail

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -115,7 +115,7 @@ jobs:
         if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}
         run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
 
-  deploy-review-app:
+  deploy_review_app:
     name: Deployment To Review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
@@ -160,9 +160,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     outputs:
-      deployment_matrix: ${{ steps.set-matrix.outputs.deployment_matrix }}
+      deployment_matrix: ${{ steps.set_matrix.outputs.deployment_matrix }}
     steps:
-      - id: set-matrix
+      - id: set_matrix
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             DEPLOYMENT_MATRIX="{ 'environment': ['${{ github.event.inputs.environment }}'] }"
@@ -215,3 +215,66 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: production
           sha: ${{ needs.build.outputs.IMAGE_TAG }}
+
+  notify_slack_of_failures:
+    name: Notify Slack of failures
+    runs-on: ubuntu-latest
+    needs:
+      [build, deploy_review_app, set_matrix, deploy_nonprod, deploy_production]
+    environment: ${{ needs.deploy_nonprod.outputs.environment_name || 'test'  }}
+    env:
+      ENVIRONMENT_NAME: ${{ needs.deploy_nonprod.outputs.environment_name || 'test'  }}
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Environment variables
+        shell: bash
+        working-directory: terraform
+        run: |
+          if ${{ needs.build_image.result == 'failure' }}
+          then
+            job=build_image
+          elif ${{ needs.deploy_review_app.result == 'failure' }}
+          then
+            job=deploy_review_app
+            review=true
+          elif ${{ needs.set_matrix.result == 'failure' }}
+          then
+            job=set_matrix
+          elif ${{ needs.deploy_nonprod.result == 'failure' }}
+          then
+            job=deploy_nonprod
+          elif ${{ needs.deploy_production.result == 'failure' }}
+          then
+            job=deploy_production
+          fi
+
+          tf_vars_file=aks/config/${{ env.ENVIRONMENT_NAME }}.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "JOB=${job}" >> $GITHUB_ENV
+          echo "REVIEW=${review}" >> $GITHUB_ENV
+
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id: get_monitoring_secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify Slack channel on job failure
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: Deployment of check-the-childrens-barred-list ${{ env.REVIEW && 'review' }} failed
+          SLACK_MESSAGE: Job ${{ env.JOB }} failed
+          SLACK_WEBHOOK: ${{ steps.get_monitoring_secret.outputs.SLACK_WEBHOOK }}
+          SLACK_COLOR: failure
+          SLACK_FOOTER: Sent from Build and Deploy workflow


### PR DESCRIPTION
### Context
This service doesn't send a Slack message when deploys fail.
<!-- Why are you making this change? -->

### Changes proposed in this pull request
Based on the AYTQ workflow file, add a job that notifies Slack if any
deploys fail. Key changes from the AYTQ version are:

- Changing the name of the Azure keyvault secret that we retrieve the
  Slack webook URL from
- Normalising job names to consistently use underscores rather than
  hyphens
<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review
I pushed a version of this branch which intentionally failed the deploy_nonprod job. The resulting Slack message can be seen here https://ukgovernmentdfe.slack.com/archives/C02JFQ8M3UY/p1709046714199349 . I've since dropped the commit containing the intentional failure.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card
https://trello.com/c/da8Un8oA/1839-add-deploy-failure-reporting-to-cbl-and-find
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
