### PR TITLE
Add manage roles support UI feature

### DIFF
--- a/app/controllers/support_interface/roles_controller.rb
+++ b/app/controllers/support_interface/roles_controller.rb
@@ -9,8 +9,12 @@ module SupportInterface
     end
 
     def create
-      @role = Role.create!(role_params)
-      redirect_to support_interface_roles_path
+      @role = Role.new(role_params)
+      if @role.save
+        redirect_to support_interface_roles_path
+      else
+        render :new
+      end
     end
 
     private

--- a/app/controllers/support_interface/roles_controller.rb
+++ b/app/controllers/support_interface/roles_controller.rb
@@ -17,6 +17,19 @@ module SupportInterface
       end
     end
 
+    def edit
+      @role = Role.find(params[:id])
+    end
+
+    def update
+      @role = Role.find(params[:id])
+      if @role.update(role_params)
+        redirect_to support_interface_roles_path
+      else
+        render :edit
+      end
+    end
+
     private
 
     def role_params

--- a/app/controllers/support_interface/roles_controller.rb
+++ b/app/controllers/support_interface/roles_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class RolesController < SupportInterfaceController
+    def index
+      @roles = Role.all
+    end
+  end
+end

--- a/app/controllers/support_interface/roles_controller.rb
+++ b/app/controllers/support_interface/roles_controller.rb
@@ -3,5 +3,22 @@ module SupportInterface
     def index
       @roles = Role.all
     end
+
+    def new
+      @role = Role.new
+    end
+
+    def create
+      @role = Role.create!(role_params)
+      redirect_to support_interface_roles_path
+    end
+
+    private
+
+    def role_params
+      params.require(:role).permit(:code, :enabled, :internal ).tap do |rp|
+        rp[:enabled] = ActiveRecord::Type::Boolean.new.cast(rp[:enabled])
+      end
+    end
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,2 @@
+class Role < ApplicationRecord
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,2 +1,4 @@
 class Role < ApplicationRecord
+  validates :code, presence: true
+  validates :code, uniqueness: { case_sensitive: false }
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,6 +36,7 @@
 
       if current_dsi_user&.internal?
         header.with_navigation_item(href: "/support/features", text: "Features")
+        header.with_navigation_item(href: "/support/roles", text: "Check role codes")
         header.with_navigation_item(href: "/support/uploads/new", text: "File upload")
       end
     end %>

--- a/app/views/support_interface/roles/edit.html.erb
+++ b/app/views/support_interface/roles/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Edit role</h1>
+
+    <%= form_with model: @role, url: support_interface_role_path(@role), method: :put do |form| %>
+      <%= form.govuk_text_field :code, required: true %>
+      <%= form.govuk_check_box :internal, true %>
+      <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/roles/index.html.erb
+++ b/app/views/support_interface/roles/index.html.erb
@@ -24,7 +24,7 @@
                 <%= govuk_tag(text: "not enabled", colour: "red") %>
               <% end %>
             </td>
-            <td class="govuk-table__cell"></td>
+            <td class="govuk-table__cell"><%= link_to "Edit", edit_support_interface_role_path(role) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/support_interface/roles/index.html.erb
+++ b/app/views/support_interface/roles/index.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Check role codes</h1>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Code</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header"></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @roles.each do |role| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= role.code %></th>
+            <td class="govuk-table__cell"></td>
+            <td class="govuk-table__cell"></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+  </div>
+</div>

--- a/app/views/support_interface/roles/index.html.erb
+++ b/app/views/support_interface/roles/index.html.erb
@@ -3,6 +3,8 @@
 
     <h1 class="govuk-heading-l">Check role codes</h1>
 
+    <%= link_to "Add role", new_support_interface_role_path, class: "govuk-button" %>
+
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/support_interface/roles/index.html.erb
+++ b/app/views/support_interface/roles/index.html.erb
@@ -17,7 +17,13 @@
         <% @roles.each do |role| %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"><%= role.code %></th>
-            <td class="govuk-table__cell"></td>
+            <td class="govuk-table__cell">
+              <% if role.enabled? %>
+                <%= govuk_tag(text: "enabled", colour: "green") %>
+              <% else %>
+                <%= govuk_tag(text: "not enabled", colour: "red") %>
+              <% end %>
+            </td>
             <td class="govuk-table__cell"></td>
           </tr>
         <% end %>

--- a/app/views/support_interface/roles/new.html.erb
+++ b/app/views/support_interface/roles/new.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">New role</h1>
+
+    <%= form_with model: @role, url: support_interface_roles_path, method: :post do |form| %>
+      <%= form.govuk_text_field :code, required: true %>
+      <%= form.govuk_check_box :internal, true %>
+      <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -13,6 +13,13 @@ shared:
     - upload_file_hash
     - created_at
     - updated_at
+  :roles:
+    - id
+    - code
+    - enabled
+    - internal
+    - created_at
+    - updated_at
   :sessions:
     - id
     - session_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
 
     mount FeatureFlags::Engine => "/features"
 
-    resources :roles, only: %i[index new create]
+    resources :roles, only: %i[index new create edit update]
     resources :uploads, only: %i[new create]
     get "/uploads/preview", to: "uploads#preview", as: :upload_preview
     post "/uploads/confirm", to: "uploads#confirm", as: :upload_confirm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
 
     mount FeatureFlags::Engine => "/features"
 
+    resources :roles, only: %i[index]
     resources :uploads, only: %i[new create]
     get "/uploads/preview", to: "uploads#preview", as: :upload_preview
     post "/uploads/confirm", to: "uploads#confirm", as: :upload_confirm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
 
     mount FeatureFlags::Engine => "/features"
 
-    resources :roles, only: %i[index]
+    resources :roles, only: %i[index new create]
     resources :uploads, only: %i[new create]
     get "/uploads/preview", to: "uploads#preview", as: :upload_preview
     post "/uploads/confirm", to: "uploads#confirm", as: :upload_confirm

--- a/db/migrate/20240304091643_create_roles.rb
+++ b/db/migrate/20240304091643_create_roles.rb
@@ -1,0 +1,11 @@
+class CreateRoles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :roles do |t|
+      t.string :code, null: false
+      t.boolean :enabled, null: false, default: false
+      t.boolean :internal, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240304093302_add_unique_index_to_code_field_in_roles.rb
+++ b/db/migrate/20240304093302_add_unique_index_to_code_field_in_roles.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToCodeFieldInRoles < ActiveRecord::Migration[7.1]
+  def change
+    add_index :roles, 'lower(code)', unique: true, name: 'index_roles_on_lower_code'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_17_114434) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_04_091643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -65,6 +65,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_17_114434) do
     t.text "improvement_suggestion", null: false
     t.boolean "contact_permission_given", null: false
     t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.string "code", null: false
+    t.boolean "enabled", default: false, null: false
+    t.boolean "internal", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_04_091643) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_04_093302) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_091643) do
     t.boolean "internal", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index "lower((code)::text)", name: "index_roles_on_lower_code", unique: true
   end
 
   create_table "search_logs", force: :cascade do |t|

--- a/lib/tasks/seed_role_codes.rake
+++ b/lib/tasks/seed_role_codes.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+namespace :db do
+  desc "Seeds role codes from environment into the database"
+  task seed_role_codes: :environment do
+    if ENV["DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE"]
+      Role.find_or_create_by!(code: ENV["DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE"]) do |role|
+        role.enabled = true
+        role.internal = true
+      end
+    end
+
+    if ENV["DFE_SIGN_IN_API_ROLE_CODES"]
+      ENV["DFE_SIGN_IN_API_ROLE_CODES"].split(",").each do |role_code|
+        Role.find_or_create_by!(code: role_code) do |role|
+          role.enabled = true
+        end
+      end
+    end
+
+    roles = Role.all
+
+    if roles.any?
+      puts "Roles in the database:"
+      Role.all.find_each do |role|
+        puts "Role: #{role.code} enabled: #{role.enabled} internal: #{role.internal}"
+      end
+    end
+  end
+end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :role do
+    code { "TestCode" }
+    enabled { false }
+  end
+end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :role do
     code { "TestCode" }
     enabled { false }
+    internal { false }
   end
 end

--- a/spec/system/support_interface/support_user_views_check_role_codes_spec.rb
+++ b/spec/system/support_interface/support_user_views_check_role_codes_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing Check role codes" do
+  include ActivateFeaturesSteps
+  include AuthenticationSteps
+
+  scenario "Staff user views Check role codes", test: :with_stubbed_auth do
+    given_the_service_is_open
+    and_i_am_signed_in_as_an_internal_user_via_dsi
+    and_roles_exist
+    when_i_navigate_to_the_roles_section
+    then_i_can_see_roles
+  end
+
+  private
+
+  def and_roles_exist
+    FactoryBot.create(:role, code: "TestCode")
+  end
+
+  def when_i_navigate_to_the_roles_section
+    visit support_interface_root_path
+    click_link "Check role codes"
+  end
+
+  def then_i_can_see_roles
+    expect(page).to have_content "TestCode"
+  end
+end
+
+

--- a/spec/system/support_interface/support_user_views_check_role_codes_spec.rb
+++ b/spec/system/support_interface/support_user_views_check_role_codes_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe "Viewing Check role codes" do
     and_roles_exist
     when_i_navigate_to_the_roles_section
     then_i_can_see_roles
+    when_i_add_a_role
+    then_the_role_is_added
+    when_i_edit_the_role
+    then_the_role_is_updated
   end
 
   private
@@ -28,6 +32,43 @@ RSpec.describe "Viewing Check role codes" do
   def then_i_can_see_roles
     expect(page).to have_content "TestCode"
   end
+
+  def when_i_add_a_role
+    click_link "Add role"
+    fill_in "Code", with: "AnotherCode"
+    click_button "Continue"
+  end
+
+  def then_the_role_is_added
+    expect(page).to have_content "AnotherCode"
+
+    within last_row_of_roles_table do
+      expect(page).to have_content "enabled"
+    end
+  end
+
+  def when_i_edit_the_role
+    within last_row_of_roles_table do
+      click_link "Edit"
+    end
+
+    fill_in "Code", with: "UpdatedCode"
+    select "No", from: "Enabled"
+    click_button "Continue"
+  end
+
+  def then_the_role_is_updated
+    expect(page).to have_content "UpdatedCode"
+    expect(page).to_not have_content "AnotherCode"
+
+    within last_row_of_roles_table do
+      expect(page).to have_content "not enabled"
+    end
+  end
+
+  private
+
+  def last_row_of_roles_table
+    all(".govuk-table__row").last
+  end
 end
-
-


### PR DESCRIPTION
### Context

We currently manage roles via checks on role codes stored in environment variables. This means developer support is necessary for role management.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Add roles management to the support UI.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I've used https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/555 as a basis for this PR but omitted the feature flag on the assumption the follow up PR to authorise via db role codes would be quick to follow. Happy to add FFs if this isn't the case.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/A75qevut/1841-add-manage-roles-support-ui-feature
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
