### PR TITLE
Replace role management via environment variable with the support interface UI

### DIFF
--- a/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
+++ b/app/lib/dfe_sign_in_api/get_user_access_to_service.rb
@@ -13,8 +13,8 @@ module DfESignInApi
       response = client.get(endpoint)
 
       if response.success? && response.body.key?("roles")
-        response.body["roles"].find { |role| role["code"] == ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE") } ||
-          response.body["roles"].find { |role| authorised_role_codes.include?(role["code"]) }
+        response.body["roles"].find { |role| Role.enabled.internal.pluck(:code).include?(role["code"]) } ||
+          response.body["roles"].find { |role| Role.enabled.external.pluck(:code).include?(role["code"]) }
       end
     end
 

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -27,7 +27,7 @@ class DsiUser < ApplicationRecord
   end
 
   def internal?
-    DfESignIn.bypass? || current_session&.role_code == ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
+    DfESignIn.bypass? || Role.enabled.internal.pluck(:code).include?(current_session&.role_code)
   end
 
   def current_session

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,8 @@
 class Role < ApplicationRecord
   validates :code, presence: true
   validates :code, uniqueness: { case_sensitive: false }
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :internal, -> { where(internal: true) }
+  scope :external, -> { where(internal: false) }
 end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,7 +1,13 @@
 FactoryBot.define do
   factory :role do
-    code { "TestCode" }
+    sequence(:code) { |n| "TestCode-#{n}" }
     enabled { false }
     internal { false }
+    trait :enabled do
+      enabled { true }
+    end
+    trait :internal do
+      internal { true }
+    end
   end
 end

--- a/spec/models/dsi_user_spec.rb
+++ b/spec/models/dsi_user_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe DsiUser, type: :model do
 
     context "when the user has the internal role in their current session" do
       let!(:dsi_user_session) do
-        create(:dsi_user_session, dsi_user:, role_code: ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE"))
+        create(:dsi_user_session, dsi_user:, role_code: create(:role, :enabled, :internal).code)
       end
 
       it "returns true" do

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -84,13 +84,10 @@ module AuthenticationSteps
   end
 
   def role_codes(internal: false)
-    role_codes = ENV.fetch("DFE_SIGN_IN_API_ROLE_CODES").split(",")
-    role_codes << internal_user_role_code if internal
-    role_codes
-  end
-
-  def internal_user_role_code
-    ENV.fetch("DFE_SIGN_IN_API_INTERNAL_USER_ROLE_CODE")
+    [].tap do |ary|
+      ary << create(:role, :enabled).code
+      ary << create(:role, :enabled, :internal).code if internal
+    end
   end
 
   def when_i_visit_the_sign_in_page


### PR DESCRIPTION
### Context

We currently manage roles via checks on role codes stored in environment variables. This means developer support is necessary for role management.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Checks user access to the service via roles stored in the database.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

Role codes have been populated on all environments, this is good to merge once approved.
<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/CdLVoxt3/1842-replace-role-management-via-environment-variable-with-the-support-interface-ui
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
