### PR TITLE
Fix `Role#internal` unchecked checkbox issue

### DIFF
--- a/app/controllers/support_interface/roles_controller.rb
+++ b/app/controllers/support_interface/roles_controller.rb
@@ -33,8 +33,9 @@ module SupportInterface
     private
 
     def role_params
-      params.require(:role).permit(:code, :enabled, :internal ).tap do |rp|
+      params.require(:role).permit(:code, :enabled, :internal).tap do |rp|
         rp[:enabled] = ActiveRecord::Type::Boolean.new.cast(rp[:enabled])
+        rp[:internal] ||= false
       end
     end
   end

--- a/app/views/support_interface/roles/edit.html.erb
+++ b/app/views/support_interface/roles/edit.html.erb
@@ -5,7 +5,7 @@
 
     <%= form_with model: @role, url: support_interface_role_path(@role), method: :put do |form| %>
       <%= form.govuk_text_field :code, required: true %>
-      <%= form.govuk_check_box :internal, true %>
+      <%= form.govuk_check_box :internal, true, multiple: false %>
       <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/support_interface/roles/index.html.erb
+++ b/app/views/support_interface/roles/index.html.erb
@@ -10,6 +10,7 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Code</th>
           <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header">Access</th>
           <th scope="col" class="govuk-table__header"></th>
         </tr>
       </thead>
@@ -23,6 +24,9 @@
               <% else %>
                 <%= govuk_tag(text: "not enabled", colour: "red") %>
               <% end %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= govuk_tag(text: role.internal? ? "internal" : "external", colour: "orange") %>
             </td>
             <td class="govuk-table__cell"><%= link_to "Edit", edit_support_interface_role_path(role) %></td>
           </tr>

--- a/app/views/support_interface/roles/new.html.erb
+++ b/app/views/support_interface/roles/new.html.erb
@@ -5,7 +5,7 @@
 
     <%= form_with model: @role, url: support_interface_roles_path, method: :post do |form| %>
       <%= form.govuk_text_field :code, required: true %>
-      <%= form.govuk_check_box :internal, true %>
+      <%= form.govuk_check_box :internal, true, multiple: false %>
       <%= form.govuk_select :enabled, options_for_select([["Yes", true], ["No", false]]) %>
       <%= form.govuk_submit %>
     <% end %>

--- a/spec/system/support_interface/support_user_views_check_role_codes_spec.rb
+++ b/spec/system/support_interface/support_user_views_check_role_codes_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Viewing Check role codes" do
   def when_i_add_a_role
     click_link "Add role"
     fill_in "Code", with: "AnotherCode"
+    check "Internal", visible: false
     click_button "Continue"
   end
 
@@ -44,6 +45,7 @@ RSpec.describe "Viewing Check role codes" do
 
     within last_row_of_roles_table do
       expect(page).to have_content "enabled"
+      expect(page).to have_content "internal"
     end
   end
 
@@ -53,6 +55,7 @@ RSpec.describe "Viewing Check role codes" do
     end
 
     fill_in "Code", with: "UpdatedCode"
+    uncheck "Internal", visible: false
     select "No", from: "Enabled"
     click_button "Continue"
   end
@@ -63,6 +66,7 @@ RSpec.describe "Viewing Check role codes" do
 
     within last_row_of_roles_table do
       expect(page).to have_content "not enabled"
+      expect(page).to have_content "external"
     end
   end
 


### PR DESCRIPTION
### Context

We recently had a problem on CTR with Roles where a form create/update action would persist a nil value on `Role#internal`.
While this isn't possible on the CBL service because we have a db constraint, I spotted an issue with unpermitted params.
<!-- Why are you making this change? -->

![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/f329a61e-c606-418e-a007-92260ed8afc6)


### Changes proposed in this pull request

- Make the Role#internal checkbox a singular param value.
- Default to false if no internal param value is send (ie. an unchecked field)
- Add the internal access value to the Roles index, this gives more info to a support user.



<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/MLOMyEH4/1900-amend-cbl-roleinternal-checkbox
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
