### PR TITLE
Update dfe-analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "omniauth_openid_connect"
 gem "omniauth-rails_csrf_protection"
 
 # Sending events to BigQuery
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.12.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.12.1"
 
 # Scheduling jobs
 gem "clockwork"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 7f0bcd0a3e19910e6c1ff34c80fd61877f3a6389
-  tag: v1.12.0
+  revision: ad642bc91bc7228d06e8c3d5c175365aef1a9e40
+  tag: v1.12.1
   specs:
-    dfe-analytics (1.12.0)
+    dfe-analytics (1.12.1)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -175,9 +175,9 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-apis-bigquery_v2 (0.65.0)
+    google-apis-bigquery_v2 (0.66.0)
       google-apis-core (>= 0.14.0, < 2.a)
-    google-apis-core (0.14.0)
+    google-apis-core (0.14.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 1.9)
       httpclient (>= 2.8.1, < 3.a)
@@ -185,19 +185,19 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
       rexml
-    google-cloud-bigquery (1.48.1)
+    google-cloud-bigquery (1.49.0)
       concurrent-ruby (~> 1.0)
       google-apis-bigquery_v2 (~> 0.62)
       google-apis-core (~> 0.13)
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-cloud-core (1.6.1)
+    google-cloud-core (1.7.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
     google-cloud-env (2.1.1)
       faraday (>= 1.0, < 3.a)
-    google-cloud-errors (1.3.1)
+    google-cloud-errors (1.4.0)
     googleauth (1.11.0)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.1)


### PR DESCRIPTION


### Context

We use the de-analytics library. Some entity events have not been sent as BigQuery the library was sending `event_tags = [nil]` which was unexpected.

### Changes proposed in this pull request

This looks to have been fixed in an update to the library 1.12.1.

The fix -> https://github.com/DFE-Digital/dfe-analytics/pull/118

The errors -> https://dfe-teacher-services.sentry.io/issues/5061926076/

Update dfe-analytics.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
