### PR TITLE
Log all searches

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -15,14 +15,16 @@ class SearchesController < ApplicationController
     @search_form = SearchForm.new(search_params)
 
     if @search_form.valid?
-      render :no_record and return if record.nil?
+      result_returned = record.present?
 
       SearchLog.create!(
         dsi_user: current_dsi_user,
         last_name: @search_form.last_name,
         date_of_birth: @search_form.date_of_birth.to_fs(:db),
-        result_returned: true
+        result_returned:
       )
+
+      render :no_record and return unless result_returned
     else
       render :new
     end

--- a/spec/system/user_searches_with_no_matching_record_spec.rb
+++ b/spec/system/user_searches_with_no_matching_record_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "No matching record search", type: :system do
     and_i_search_for_a_different_last_name
     and_i_enter_their_date_of_birth
     and_i_click_search
+    and_my_search_is_logged
     then_i_see_the_no_record_page
     and_event_tracking_is_working
   end
@@ -47,5 +48,11 @@ RSpec.describe "No matching record search", type: :system do
   def then_i_see_the_no_record_page
     expect(page).to have_content "No record found"
     expect(page).to have_content "Random name"
+  end
+
+  def and_my_search_is_logged
+    expect(SearchLog.last.last_name).to eq "Random name"
+    expect(SearchLog.last.date_of_birth).to eq @record.date_of_birth
+    expect(SearchLog.last.result_returned).to eq false
   end
 end


### PR DESCRIPTION


### Context

We log searches for analytics. We should be logging all searches but are currently only logging searches that return a match.

### Changes proposed in this pull request

Log all searches and set result_returned to true when there is a result.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
