### PR TITLE
Make sign out flow consistent with other services

### DIFF
--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -3,5 +3,6 @@ class SignOutController < ApplicationController
   before_action :reset_session
 
   def new
+    redirect_to sign_in_path
   end
 end

--- a/app/views/sign_out/new.html.erb
+++ b/app/views/sign_out/new.html.erb
@@ -1,7 +1,0 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You are now signed out</h1>
-
-    <%= govuk_button_link_to "Continue", root_path  %>
-  </div>
-</div>

--- a/spec/system/user_signs_out_spec.rb
+++ b/spec/system/user_signs_out_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "DSI authentication", type: :system do
   end
 
   def then_i_am_redirected_to_the_sign_in_page
-    expect(page).to have_content "You are now signed out"
+    expect(page).to have_content "Sign in to check the children’s barred list"
+    expect(page).to have_button "Sign in"
   end
 end


### PR DESCRIPTION
### Context

Clicking sign out takes the user to the sign out page, in other services we redirect the sign out flow to the sign in page after resetting the session.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Redirect the user to the sign in page on sign out.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/KNNAuZJc/1909-sign-out-flow-is-inconsistent
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
