### PR TITLE
Add custom error handler for missing i18n translations

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,13 @@
+module I18n
+  class SentryExceptionHandler
+    def call(exception, _locale, _key, _options)
+      if Rails.env.production? && exception.is_a?(MissingTranslation)
+        Sentry.capture_exception(exception)
+      else
+        raise exception.respond_to?(:to_exception) ? exception.to_exception : exception
+      end
+    end
+  end
+end
+
+I18n.exception_handler = I18n::SentryExceptionHandler.new

--- a/spec/config/initializers/i18n_spec.rb
+++ b/spec/config/initializers/i18n_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe I18n::SentryExceptionHandler do
+  let(:key) { "missing.translation" }
+
+  describe "#call" do
+    it "raises exceptions in non-production environments" do
+      expect { I18n.translate(key) }.to raise_exception(I18n::MissingTranslationData)
+    end
+    context "in production" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        allow(Sentry).to receive(:capture_exception)
+      end
+      it "captures the exception in Sentry" do
+        I18n.translate(key)
+        expect(Sentry).to have_received(:capture_exception).with(
+          I18n::MissingTranslation.new(:en, key)
+        )
+      end
+    end
+  end
+end

--- a/spec/validators/day_month_year_validator_spec.rb
+++ b/spec/validators/day_month_year_validator_spec.rb
@@ -10,6 +10,16 @@ class Validatable
 end
 
 RSpec.describe DayMonthYearValidator do
+  # We don't have translations for our Validatable test class
+  # avoid I18n::MissingTranslationData exceptions by turning off
+  # I18n.exception_handler for this particular spec.
+  around do |example|
+    exception_handler = I18n.exception_handler
+    I18n.exception_handler = nil
+    example.run
+    I18n.exception_handler = exception_handler
+  end
+
   subject(:validatable) { Validatable.new(attributes) }
 
   describe "#validate" do
@@ -42,7 +52,7 @@ RSpec.describe DayMonthYearValidator do
         expect(validatable.errors[:date_attribute]).to include("is invalid")
       end
     end
-    
+
     context "when the date is negative" do
       let(:attributes) { { day: -1, month: "6", year: "1990" } }
 
@@ -162,7 +172,7 @@ RSpec.describe DayMonthYearValidator do
         expect(validatable.errors[:date_attribute].first).to include("missing_day_and_year")
       end
     end
-    
+
     context "when month and year are missing" do
       let(:attributes) { { day: "15", month: nil, year: nil } }
 


### PR DESCRIPTION
### Context

In the event of a missing or incorrect key, default i18n behaviour in Rails is to simply render a missing key error on the page. We can improve this to increase the likelihood of finding such errors.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Adds a custom I18n exception handler which sends missing translation errors to Sentry when running in production mode.
In test/development mode it raises the exception.

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/lSceaiee/1922-improve-handling-of-missing-i18n-keys
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
