### PR TITLE
Remove improvement_suggestion from PII list

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -7,7 +7,6 @@ shared:
     - uid
   :feedbacks:
     - email
-    - improvement_suggestion
   :search_logs:
     - last_name
     - date_of_birth


### PR DESCRIPTION
### Context

We monitor feedback on the BigQuery dashboards so this needs to be sent without obfuscation.

### Changes proposed in this pull request

Remove it from analytics_pii.yml

### Checklist

- [x] Rebased main
- [x] Cleaned commit history

