### PR TITLE
Display search metadata on search results pages

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -17,11 +17,11 @@ class SearchesController < ApplicationController
     if @search_form.valid?
       result_returned = record.present?
 
-      SearchLog.create!(
+      @search = SearchLog.create!(
         dsi_user: current_dsi_user,
         last_name: @search_form.last_name,
         date_of_birth: @search_form.date_of_birth.to_fs(:db),
-        result_returned:
+        result_returned:,
       )
 
       render :no_record and return unless result_returned

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -4,7 +4,7 @@ class SearchForm
   include ActiveModel::Model
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :last_name, :day, :month, :year
+  attr_accessor :last_name, :day, :month, :year, :searched_at
 
   validates :last_name, presence: true
   validates :date_of_birth, presence: true

--- a/app/views/searches/no_record.html.erb
+++ b/app/views/searches/no_record.html.erb
@@ -1,19 +1,17 @@
 <% content_for :page_title, "No record found" %>
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => root_path, "Search results" => nil }) %>
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: { "Home" => root_path, "Search results" => nil }) %>
+  <span class="govuk-caption-m">
+    Searched at <%= @search.created_at.to_fs(:time_on_date_long) %>
+  </span>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">No record found on the Children’s Barred List</h1>
 
-    <%= govuk_summary_list(
-      rows: [
-        { key: { text: "Last name" }, value: { text: @search_form.last_name } },
-        { key: { text: "Date of birth" }, value: { text: @search_form.date_of_birth.to_fs(:long_uk) } }
-      ])
-    %>
-
     <p class="govuk_body">
-      There is no record on the children’s barred list with this last name and date of birth.
+      No record found for <%= @search.last_name %> born on <%= Date.parse(@search.date_of_birth).to_fs(:long_uk) %>
     </p>
 
     <p class="govuk_body">

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :page_title, "Possible match with the children’s barred list" %>
-<% content_for :breadcrumbs, govuk_breadcrumbs(breadcrumbs: { "Home" => root_path, "Search results" => nil }) %>
+<% content_for :breadcrumbs do %>
+  <%= govuk_breadcrumbs(breadcrumbs: { "Home" => root_path, "Search results" => nil }) %>
+  <span class="govuk-caption-m">
+    Searched at <%= @search.created_at.to_fs(:time_on_date_long) %>
+  </span>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -21,4 +26,3 @@
     </p>
   </div>
 </div>
-

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,2 @@
 Date::DATE_FORMATS[:long_uk] = "%e %B %Y"
+Time::DATE_FORMATS[:time_on_date_long] = "%-I:%M%P on %-d %B %Y"

--- a/spec/system/user_searches_with_matching_record_spec.rb
+++ b/spec/system/user_searches_with_matching_record_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe "Valid search", type: :system do
   end
 
   def then_i_see_a_result
+    expect(page).to have_content "Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}"
     expect(page).to have_content "Possible match with the children’s barred list"
     expect(page).to have_content @record.last_name
+    expect(page).to have_content Date.parse(@record.date_of_birth).to_fs(:long_uk)
   end
 
   def and_my_search_is_logged

--- a/spec/system/user_searches_with_no_matching_record_spec.rb
+++ b/spec/system/user_searches_with_no_matching_record_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe "No matching record search", type: :system do
   end
 
   def then_i_see_the_no_record_page
+    expect(page).to have_content "Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}"
     expect(page).to have_content "No record found"
-    expect(page).to have_content "Random name"
+    expect(page).to have_content(
+      "No record found for Random name born on #{Date.parse(@record.date_of_birth).to_fs(:long_uk)}")
   end
 
   def and_my_search_is_logged


### PR DESCRIPTION
### Context

In CTR we have made a new version for testing which includes playing back the terms a users searched when they get no results. This is because UR has identified that some users actively look for no results for teaching assistants and other staff, and may screenshot and/or print the page for their evidence.

<!-- Why are you making this change? -->

### Changes proposed in this pull request

Regardless of a match for the search criteria, replay the criteria in the results content and add a searched at timestamp in the breadcrumbs.

#### Match found
![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/bc53e6b5-db37-4ac1-8297-54e7b73e9956)

#### No match found
![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/1f9a9feb-9582-4337-a338-2814adef510e)

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/Fy2xAVhq/1933-update-cbl-with-search-terms-pattern-from-ctr
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
