### PR TITLE
Don't require auth for feedback

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,4 +1,7 @@
 class FeedbacksController < ApplicationController
+  skip_before_action :authenticate_dsi_user!
+  skip_before_action :handle_expired_session!
+
   def new
     @feedback = Feedback.new
   end

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,2 +1,2 @@
-Date::DATE_FORMATS[:long_uk] = "%e %B %Y"
+Date::DATE_FORMATS[:long_uk] = "%-d %B %Y"
 Time::DATE_FORMATS[:time_on_date_long] = "%-I:%M%P on %-d %B %Y"


### PR DESCRIPTION
### Context

We're currently redirecting users that haven't authenticated back to the start page when they click the feedback link. This makes it appear that the link doesn't work as they're redirected back to the start page from the start page.

### Changes proposed in this pull request

Don't do that.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history

