### PR TITLE
Make sign out a post request via button_to form

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -7,11 +7,15 @@ $govuk-images-path: "/";
 @import "govuk-frontend/dist/govuk/all";
 
 button.govuk-header__link {
-  background: none !important;
+  background: none;
   border: none;
-  padding: 0 !important;
-  color: #fff;
+  padding: 0;
+  color: $govuk-body-background-colour;
   cursor: pointer;
   font-size: 1rem;
   font-weight: bold;
+}
+
+button.govuk-header__link:focus {
+  background-color: $govuk-focus-colour;
 }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -5,3 +5,13 @@ $govuk-fonts-path: "/";
 $govuk-images-path: "/";
 
 @import "govuk-frontend/dist/govuk/all";
+
+button.govuk-header__link {
+  background: none !important;
+  border: none;
+  padding: 0 !important;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: bold;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 require "dfe/analytics/filtered_request_event"
+require "govuk_component/header_component"
 
 class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -28,7 +28,11 @@
     <%= govuk_header(service_name: t("service.name")) do |header|
       if request.path != main_app.not_authorised_path
         if current_dsi_user
-          header.with_navigation_item(href: main_app.dsi_sign_out_path(id_token_hint: session[:id_token]), text: "Sign out")
+          header.with_navigation_item(
+            href: main_app.dsi_sign_out_post_path({ id_token_hint: session[:id_token] }),
+            post: true,
+            text: "Sign out"
+          )
         else
           header.with_navigation_item(href: main_app.sign_in_path, text: "Sign in")
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "/sign-in", to: "sign_in#new"
   get "/sign-out", to: "sign_out#new"
   get "/auth/dfe/sign-out", to: "sign_out#new", as: :dsi_sign_out
+  post "/auth/dfe/sign-out", to: "sign_out#new", as: :dsi_sign_out_post
 
   get "/auth/dfe/callback", to: "omniauth_callbacks#dfe"
   post "/auth/developer/callback", to: "omniauth_callbacks#dfe_bypass"

--- a/lib/govuk_component/header_component.rb
+++ b/lib/govuk_component/header_component.rb
@@ -1,0 +1,36 @@
+class GovukComponent::HeaderComponent
+  class GovukComponent::HeaderComponent::NavigationItem
+    attr_reader :post, :params
+
+    def initialize(text:, href: nil, post: false, options: {}, active: nil, classes: [], html_attributes: {})
+      @text            = text
+      @href            = href
+      @options         = options
+      @active_override = active
+      @post            = post
+
+      if button_to?
+        query = URI(@href).query
+        @params = query.present? ? Hash[URI.decode_www_form(query)] : {}
+      end
+
+      super(classes:, html_attributes:)
+    end
+
+    def button_to?
+      post == true
+    end
+
+    def call
+      tag.li(**html_attributes) do
+        if button_to?
+          button_to(text, href, params:, class: "#{brand}-header__link", **options)
+        elsif link?
+          link_to(text, href, class: "#{brand}-header__link", **options)
+        else
+          text
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_component/header_component.rb
+++ b/lib/govuk_component/header_component.rb
@@ -1,6 +1,6 @@
 class GovukComponent::HeaderComponent
-  class GovukComponent::HeaderComponent::NavigationItem
-    attr_reader :post, :params
+  class NavigationItem
+    attr_reader :post
 
     def initialize(text:, href: nil, post: false, options: {}, active: nil, classes: [], html_attributes: {})
       @text            = text
@@ -8,11 +8,6 @@ class GovukComponent::HeaderComponent
       @options         = options
       @active_override = active
       @post            = post
-
-      if button_to?
-        query = URI(@href).query
-        @params = query.present? ? Hash[URI.decode_www_form(query)] : {}
-      end
 
       super(classes:, html_attributes:)
     end
@@ -24,7 +19,7 @@ class GovukComponent::HeaderComponent
     def call
       tag.li(**html_attributes) do
         if button_to?
-          button_to(text, href, params:, class: "#{brand}-header__link", **options)
+          button_to(text, href, class: "#{brand}-header__link", **options)
         elsif link?
           link_to(text, href, class: "#{brand}-header__link", **options)
         else

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -24,10 +24,11 @@ RSpec.describe "DSI authentication", type: :system do
 
   def then_i_am_signed_in
     within("header") do
-      expect(page).to have_link("Sign out")
-      sign_out_link = find_link("Sign out")
-      # Expect the token from mocked auth to be in the sign out link
-      expect(sign_out_link[:href]).to include "id_token_hint=abc123"
+      expect(page).to have_button("Sign out")
+      sign_out_button = find_button("Sign out")
+      sign_out_form = sign_out_button.ancestor("form")
+      # Expect the token from mocked auth to be in the sign out form action
+      expect(sign_out_form["action"]).to end_with("/auth/dfe/sign-out?id_token_hint=abc123")
     end
     expect(DsiUser.count).to eq 1
     expect(DsiUserSession.count).to eq 1


### PR DESCRIPTION
### Context

Browsers which prefetch pages via links on the current page can unintentionally sign the user out by prefetching the sign out link in the header.
<!-- Why are you making this change? -->

### Changes proposed in this pull request

Extend the header component navigation item to render a sign out form using the `button_to` Rails helper.

![image](https://github.com/DFE-Digital/check-childrens-barred-list/assets/93511/e2829d7d-a203-484f-b2a5-7771b9e781b9)

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

I opted to patching the existing x-govuk header component. We could just as easily introduce our own header component.

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

https://trello.com/c/XBqfNgbL/1961-make-sign-out-a-post
<!-- http://trello.com/123-example-card -->

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
