### PR TITLE
Set time zone to London

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module CheckTheChildrensBarredList
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "London"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.


### PR DESCRIPTION
### Context

We display search times back to the user and need them to reflect BST changes.

### Changes proposed in this pull request

Set the timezone to London.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
