### PR TITLE
Change http basic auth for when service closed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,8 +12,8 @@ class ApplicationController < ActionController::Base
   def http_basic_authenticate
     valid_credentials = [
       {
-        username: ENV.fetch("SUPPORT_USERNAME", "support"),
-        password: ENV.fetch("SUPPORT_PASSWORD", "support")
+        username: ENV.fetch("SUPPORT_USERNAME", "test"),
+        password: ENV.fetch("SUPPORT_PASSWORD", "test")
       }
     ]
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "Authentication", type: :request do
     context "with valid basic auth credentials" do
       let(:credentials) do
         ActionController::HttpAuthentication::Basic.encode_credentials(
-          ENV.fetch("SUPPORT_USERNAME", "support"),
-          ENV.fetch("SUPPORT_PASSWORD", "support"),
+          ENV.fetch("SUPPORT_USERNAME", "test"),
+          ENV.fetch("SUPPORT_PASSWORD", "test"),
         )
       end
 


### PR DESCRIPTION
If the service isn't open (determined via feature flag), we have a basic auth prompt that provides some light resistance to accessing it.

This prompt is encountered regularly in local development, as the feature flag will often be inactive (after a database reset for example).

It's slightly annoying that these credentials are different from other services looked after by TRA Digital (eg - Find, AYTQ, CTR). Change them to match.