### PR TITLE
Implemnt terms and conditions acceptance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :http_basic_authenticate, unless: -> { FeatureFlags::FeatureFlag.active?(:service_open) }
   before_action :authenticate_dsi_user!
   before_action :handle_expired_session!
+  before_action :enforce_terms_and_conditions_acceptance!
 
   def http_basic_authenticate
     valid_credentials = [
@@ -62,5 +63,11 @@ class ApplicationController < ActionController::Base
     request_event.with_namespace(current_namespace) if respond_to?(:current_namespace, true)
 
     DfE::Analytics::SendEvents.do([request_event.as_json])
+  end
+
+  def enforce_terms_and_conditions_acceptance!
+    if current_dsi_user&.acceptance_required?
+      redirect_to terms_and_conditions_path
+    end
   end
 end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,6 +1,8 @@
 class SignInController < ApplicationController
   skip_before_action :authenticate_dsi_user!
   skip_before_action :handle_expired_session!
+  skip_before_action :enforce_terms_and_conditions_acceptance!
+
   before_action :reset_session
   before_action :handle_failed_sign_in, if: -> { params[:oauth_failure] == "true" }
 

--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -1,5 +1,7 @@
 class SignOutController < ApplicationController
   skip_before_action :handle_expired_session!
+  skip_before_action :enforce_terms_and_conditions_acceptance!
+
   before_action :reset_session
 
   def new

--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TermsAndConditionsController < ApplicationController
+  skip_before_action :enforce_terms_and_conditions_acceptance!
+
+  def show
+  end
+
+  def update
+    current_dsi_user.accept_terms!
+    redirect_to root_path, notice: "Terms and conditions accepted"
+  end
+end

--- a/app/models/dsi_user.rb
+++ b/app/models/dsi_user.rb
@@ -5,6 +5,8 @@ class DsiUser < ApplicationRecord
   encrypts :first_name, :last_name
   encrypts :email, deterministic: true
 
+  CURRENT_TERMS_AND_CONDITIONS_VERSION = "1.0".freeze
+
   def self.create_or_update_from_dsi(dsi_payload, role = nil)
     dsi_user = find_or_initialize_by(email: dsi_payload.info.fetch(:email))
 
@@ -24,6 +26,25 @@ class DsiUser < ApplicationRecord
     end
 
     dsi_user
+  end
+
+  def accept_terms!
+    update!(
+      terms_and_conditions_version_accepted: CURRENT_TERMS_AND_CONDITIONS_VERSION,
+      terms_and_conditions_accepted_at: Time.zone.now
+    )
+  end
+
+  def acceptance_required?
+    !current_version_accepted || acceptance_expired
+  end
+
+  def current_version_accepted
+    terms_and_conditions_version_accepted == CURRENT_TERMS_AND_CONDITIONS_VERSION
+  end
+
+  def acceptance_expired
+    terms_and_conditions_accepted_at < 12.months.ago
   end
 
   def internal?

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -83,6 +83,9 @@
             <li class="govuk-footer__inline-list-item">
               <%= govuk_link_to("Privacy notice", "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers", class: "govuk-footer__link") %>
             </li>
+            <li class="govuk-footer__inline-list-item">
+              <%= govuk_link_to("Terms and conditions", "/terms-and-conditions", class: "govuk-footer__link") %>
+            </li>
           </ul>
 
           <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">

--- a/app/views/terms_and_conditions/show.html.erb
+++ b/app/views/terms_and_conditions/show.html.erb
@@ -1,0 +1,211 @@
+<% content_for :page_title, "Terms and Conditions" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Terms and Conditions</h1>
+    <h1 class ="govuk-heading-m">
+      1. Introduction
+    </h1>
+    <p class="govuk-body">1.1 The Check a Teacher’s Record Service (as defined below) is a web service operated by the Department of Education (DfE). This web service is used by the Teaching Regulation Agency (TRA) as an executive agency to DfE to provide You with the Service (as also defined below).</p>
+
+    <p class="govuk-body">1.2 When referring to:</p>
+    <ol type="a" class="govuk-body">
+      <li class="govuk-body"> DfE, we, us or our in these Terms (as defined below), these references mean DfE and the TRA; and</li>
+
+      <li class="govuk-body"> You, your and your organisation have the meaning given to them in Clause 2 below.</li>
+    </ol>
+
+    <p class="govuk-body">1.3 Please read these Terms carefully before You access and start to use the Service as they tell You the rules for using the Service.</p>
+
+    <p class="govuk-body">1.4 By accessing and using the Service, You confirm that You accept and are bound by the Terms and have a valid basis for accessing and using the Service. If You do not agree to these Terms, You are not permitted to use this Service and You should not attempt to do so.</p>
+
+    <p class="govuk-body">1.5 These Terms refer to the following additional terms, which also apply to your use of the Service: </p>
+    <ol type="a" class="govuk-body">
+      <li class="govuk-body">our privacy notice that details the processing of Personal Data through the Service (as may be amended by us from time to time);</li>
+
+      <li class="govuk-body">any <a class="govuk-link" href="https://interactions.signin.education.gov.uk/terms">DfE Sign-In</a> terms and conditions that govern the access to the Service (as such terms of use may be amended by us from time to time).</li>
+    </ol>
+    <p class="govuk-body">1.6 Where there is a separate data sharing agreement, memorandum of understanding or any other agreement (as applicable) in place between DfE and your organisation, these Terms are mandatory and supplemental to the obligations set out in any such separate agreements or memorandum of understanding. Please note that these Terms include an Annex which contain additional obligations which will only apply where there is no separate data sharing provisions in place between DfE and your organisation. In the event of any conflict or inconsistency between these Terms and any separate data sharing agreement, memorandum of understanding or any other agreement between DfE and your organisation, these Terms shall prevail.</p>
+
+    <p class="govuk-body">1.7 The Service is a free service available for local authorities, schools, multi-academy trusts, accredited teacher training providers, other professional regulators, teacher supply agencies and other authorised organisations as permitted access by the DfE to view the record of any:</p>
+    <ol type="a" class="govuk-body">
+      <li class="govuk-body">trainee, newly qualified or fully qualified teacher holding early years teacher status or qualified teacher status – with the exception of teachers who have achieved qualified teacher status through holding qualified teacher learning and skills (QTLS);</li>
+
+      <li class="govuk-body">teacher with an active restriction (including any teacher with QTLS to whom this applies);</li>
+
+      <li class="govuk-body">teacher who has been the subject of a decision by the Secretary of State for Education not to impose a prohibition order following a determination by a professional conduct panel of unacceptable professional conduct, conduct that may bring the teaching profession into disrepute or conviction of a relevant offence</li>
+
+      <li class="govuk-body">individual with a teacher reference number not included in the above.</li>
+    </ol>
+
+    <h2 class ="govuk-heading-m">
+      2. Definitions
+    </h2>
+    <p class="govuk-body">The following definitions are used in these Terms:</p>
+
+    <p class="govuk-body">Data Protection Legislation: means (i) the UK GDPR and EU GDPR (as applicable); (ii) the Data Protection Act 2018 to the extent that it relates to processing of Personal Data and privacy as amended updated or replaced from time to time; and (iii) all applicable law about the processing of Personal Data and privacy in force from time to time which applies to an organisation relating to the use of Personal Data.</p>
+
+    <p class="govuk-body">Destructive Features: means any thing or device (including any software, code, file or programme) that may prevent, impair or otherwise adversely affect the operation of any computer software, hardware, network, programme or data including but not limited to computer viruses, worms, trojan horses or technologically harmful software.</p>
+
+    <p class="govuk-body">Check a Teacher’s Record: the web service through which access to the information regarding a teacher and the status of that individual is made available to certain third parties by DfE as more particularly described in Clauses 1.8 and 3.4(a), as DfE may update from time to time.</p>
+
+    <p class="govuk-body">EU GDPR: the EU General Data Protection Regulation (Regulation (EU) 2016/679).</p>
+
+    <p class="govuk-body">Personal Data: the personal data relating to an individual made available through the Service.</p>
+
+    <p class="govuk-body">Terms: means these terms and conditions that govern a user's access to and use of the Service.</p>
+
+    <p class="govuk-body">Service: means the Check a Teacher’s Record Web Service.</p>
+
+    <p class="govuk-body">UK GDPR: the EU GDPR as it forms part of the law of England and Wales, Scotland and Northern Ireland by virtue of section 3 of the European Union (Withdrawal) Act 2018.</p>
+
+    <p class="govuk-body">Valid Basis: an authorised reason to access use the Service to support your role in a) conducting safeguarding checks in line with Keeping Children Safe In Education or to comply with DfE funding requirements, b) verifying the qualified teacher status, early years teacher status, early years professional status, statutory induction status, mandatory qualification for teaching those with sensory impairments or a DfE national processional qualification, or c) an approved other use where you have written approval from DfE to use the servicethe statutory induction process.</p>
+
+    <p class="govuk-body">You, your and your organisation: means all directors, officers and employees of an organisation, that have approved access to the Service by DfE and are engaged in the performance of that organisation’s obligations to undertake statutory checks on teachers as required in legislation. </p>
+    <h2 class ="govuk-heading-m">
+      3. Terms of Use
+    </h2>
+    <p class="govuk-body">3.1 These Terms must be complied with whenever You access the Service. You acknowledge that in addition to complying with these Terms, You must also comply with all applicable law, including Data Protection Legislation.</p>
+
+    <p class="govuk-body">3.2 In accessing the Service, You also acknowledge your organisation is an independent controller, as defined in Data Protection Legislation, with responsibility for ensuring:</p>
+    <ol type="a" class="govuk-body">
+      <li class="govuk-body">your use of data obtained from the Service complies with Data Protection Legislation; and</li>
+
+      <li class="govuk-body">any processors required to access the Service on your organisation’s behalf do so with a valid basis for processing and always use any Personal Data obtained from the Service in compliance with Data Protection Legislation and in accordance with these Terms.</li>
+    </ol>
+    <p class="govuk-body">3.3 Without prejudice to Clause 3.2 and as set out in Clause 1.6, You will also need to comply with the Annex to these Terms in circumstances where your organisation does not have a separate data sharing agreement or memorandum of understanding (as applicable) in place with DfE.</p>
+
+    <p class="govuk-body">3.4 As a user of this Service, You will at all times:</p>
+    <ol type="a" class="govuk-body">
+      <li class="govuk-body">comply with the provisions of Data Protection Legislation in respect of all Personal Data, understanding that such Personal Data is provided to enable only authorised users from a registered organisation to carry out necessary checks on whether a trainee or teacher has:</li>
+      <li class="govuk-body">
+        <ol type="i" class="govuk-body">
+          <li class="govuk-body">achieved qualified teacher status, early years teacher status or early years professional status;</li>
+
+          <li class="govuk-body">completed their induction;</li>
+
+          <li class="govuk-body">been awarded a mandatory qualification for teachers of hearing impaired or visually impaired pupils;</li>
+
+          <li class="govuk-body">successfully completed a leadership or specialist national professional qualification;</li>
+
+          <li class="govuk-body">any teaching restrictions placed against them or has been the subject of a decision by the Secretary of State for Education not to impose a prohibition order following a determination by a professional conduct panel of unacceptable professional conduct or conduct that may bring the teaching profession into disrepute or the conviction of a relevant offence.</li>
+        </ol>
+      </li>
+
+      <li class="govuk-body">not disclose any Personal Data from the Service to any unauthorised third party.</li>
+
+      <li class="govuk-body">abide by all instructions, conditions and other requirements made known to You by us when accessing and using the Service.</li>
+
+      <li class="govuk-body">seek prior written advice from DfE where You are unsure whether a proposed use of the Service is permitted under Data Protection Legislation.</li>
+
+      <li class="govuk-body">indemnify and hold harmless DfE (and for the avoidance of doubt, the TRA) against any and all losses, liabilities, demands, fines, penalties, claims for compensation, costs (including without limitation legal costs), expenses or damages arising from any unauthorised use, loss or corruption of Personal Data available via the Service where the foregoing arises out of or in connection with any act or omission You have taken.</li>
+    </ol>
+    <p class="govuk-body">3.5 As a user of this Service, You understand DfE:</p>
+    <ol type="a">
+      <li class="govuk-body">takes no responsibility for the accuracy or completeness or the security of any personal data transferred to, used in or stored on your system or in your local files. In such circumstances, for the purposes of Data Protection Legislation, You understand that your organisation is the controller for any such personal data and any activities carried out with this data must comply with Data Protection Legislation.</li>
+
+      <li class="govuk-body">takes reasonable steps to ensure the quality, accuracy, and completeness of its data but accept that these factors cannot be guaranteed.</li>
+
+      <li class="govuk-body">reserves the right to reset user passwords.</li>
+
+      <li class="govuk-body">owns all intellectual property rights (which is protected by Crown copyright) in and to the Service which includes any and all data (including Personal Data) or other information or material made available or published via the Service and these rights are licensed (not sold) to You. You have no intellectual property rights in relation to the foregoing other than the right to use them in accordance with these Terms.</li>
+    </ol>
+    <p class="govuk-body">3.6 DfE may terminate these Terms and your (and your organisation's) access to and use of the Service at any time and for any reason by written notice with immediate effect.</p>
+
+    <h2 class ="govuk-heading-m">
+      4. Changes and Updates
+    </h2>
+
+    <p class="govuk-body">4.1 DfE may make changes at its discretion to the content and features of the Service at any time and for any reason without providing notice of those changes to You.</p>
+
+    <p class="govuk-body">4.2 These Terms are to be read, understood, and signed on an annual basis by You (in conjunction with any data sharing agreement or memorandum of understanding (as applicable) between DfE and your organisation) to ensure that You understand and agree to the latest provisions that apply to your access and usage of the Service.</p>
+
+    <p class="govuk-body">4.3 Your access and continued use of the Service after an update has been made signifies your acceptance of those changes.</p>
+
+    <h2 class ="govuk-heading-m">
+      5. Freedom of Information
+    </h2>
+
+    <p class="govuk-body">5.1 You acknowledge that DfE (or the TRA, acting on DfE's behalf) is subject to the requirements of the Freedom of Information Act 2000.</p>
+
+    <p class="govuk-body">5.2 This Clause 5 does not relieve any rights or obligations your organisation may have under the Freedom of Information Act 2000.</p>
+
+    <h2 class ="govuk-heading-m">
+      6. General Responsibilities
+    </h2>
+
+    <p class="govuk-body">6.1 You must understand how to use the Service and have adequate training to handle the data available within the Service in line with these Terms.</p>
+
+    <p class="govuk-body">6.2 You acknowledge that your organisation must continue (as applicable) to carry out <a class="govuk-link" href="https://www.gov.uk/government/publications/keeping-children-safe-in-education--2">safer recruitment checks</a> on all applicants set out in statutory guidance Keeping children safe in education (KCSiE) and access to this Service does not waive the need to do so.</p>
+
+    <p class="govuk-body">6.3 Whilst accessing the Service You must ensure your workstation is not overlooked and not left unlocked and unattended at any time.</p>
+
+    <p class="govuk-body">6.4 You must not make any attempt to modify the functionality of the Service.</p>
+
+    <p class="govuk-body">Your use of your password to access the Service</p>
+
+    <p class="govuk-body">6.5 If You are provided with account details (including but not limited to, a user identification code, password or any other piece of information as part of our security procedures), You must treat such information as confidential. You must keep your account details safe and not deliberately or inadvertently share your password and/or username with another individual or organisation that would allow that other individual or organisation to access or use the Service. We have the right to disable any account details, whether chosen by You or allocated by us, at any time, if in our reasonable opinion You have failed to comply with any of the provisions of these Terms.</p>
+
+    <p class="govuk-body">6.6 You must change your password immediately if You think or know it has been compromised. You must inform us without undue delay of any security breaches, suspected or otherwise (including under Data Protection Legislation or otherwise) and take immediate action to address the problem including following any instructions given to You.</p>
+
+    <p class="govuk-body">Your acceptable use of the Service</p>
+
+    <p class="govuk-body">6.7 You are responsible for ensuring that your computer system meets all relevant technical specifications necessary to use the Service or any service made available through it and that it is compatible with the Service.</p>
+
+    <p class="govuk-body">6.8 Subject to clause 3.5(d), where You have a valid basis for accessing and using the Service, you may download extracts, of any page(s) from the Service for non-commercial purposes only. You must not modify the digital copies of any data (including Personal Data), information or material (the "content") made available or published via the Service You have downloaded in any way, and You must not use any illustrations, photographs, video or audio sequences or any graphics separately from any accompanying text. Our status (and that of any identified contributors) as the authors of any content on the Service must always be acknowledged (except where the content is user-generated).</p>
+
+    <p class="govuk-body">6.9 If You use, copy, download, share or repost any part of the Service or content in breach of these Terms, your right to access and use the Service will cease immediately and You must, at our option, return or destroy any copies of any content You have made.</p>
+
+    <p class="govuk-body">6.10 You are held accountable for any actions taken in your name. You must access the Service only in a valid and authorised manner, and for a valid basis. Any other attempt to access the Service or to use the Service for a non-valid basis, may be considered a security incident and may lead to action being taken against You under the Computer Misuse Act 1990. If You knowingly disregard these Terms not only will this constitute a breach of these Terms, but it may also constitute an offence under sections 170 to 173 of the Data Protection Act 2018 or any other legislation including any enabling powers which DfE relies on to share Personal Data. We will report any such breaches to the relevant law enforcement authorities, and we will cooperate with those authorities by disclosing your identity to them. In the event of such a breach, your right to access and use the Service will cease immediately without notice.</p>
+
+    <p class="govuk-body">6.11 Except where DfE's prior written consent has been provided, You must not conduct, facilitate, authorise or permit any text or data mining or web scraping in relation to any content made available or published via the Service. This includes using (or permitting, authorising or attempting the use of):</p>
+    <ol type="a">
+      <li class="govuk-body">any "robot", "bot", "spider", "scraper" or other automated device, program, tool, algorithm, code, process or methodology to access, obtain, copy, monitor or republish any portion of the Service or any content or services accessed via the same; or</li>
+
+      <li class="govuk-body">any automated analytical technique aimed at analysing content in digital form to generate information which includes but is not limited to patterns, trends and correlations,</li>
+
+      <li class="govuk-body">the provisions in this Clause should be treated as an express reservation of our rights in this regard, including for the purposes of Article 4(3) of Digital Copyright Directive ((EU) 2019/790). This Clause shall not apply insofar as (but only to the extent that) we are unable to exclude or limit text or data mining or web scraping activity by contract under the laws which are applicable to us.</li>
+    </ol>
+    <p class="govuk-body">6.12 You must not violate or attempt to violate the security of the Service. You must not probe, scan or test the vulnerability of a system or network related to the Service. You must not misuse our Service by knowingly introducing Destructive Features. You must not attempt to gain unauthorised access or authentication to our Service (or any data held within it), the server on which our Service is stored, or any server, computer or database connected to our Service, through data mining, web scraping, hacking, spoofing, using another person’s password or by any other means. You must not attack our Service through a denial-of-service attack or a distributed denial-of service attack. Each of these acts is a criminal offence. We will report any such offence to the relevant law enforcement authorities and cooperate with them to determine your identity. In the event of such a breach your rights to use the Service will cease immediately.</p>
+    <h2 class ="govuk-heading-m">
+      7. Our Responsibilities and Liabilities
+    </h2>
+
+    <p class="govuk-body">7.1 <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter">The Department for Education’s Personal Information Charter</a> explains the standards expected of DfE when DfE, collects, holds or uses personal data.</p>
+
+    <p class="govuk-body">7.2 We exclude all implied conditions, warranties, representations or other terms that may apply to the Service, or any other content or data held within it. Nothing in these Terms shall limit either party’s liability to the other for: (i) death or personal injury resulting from the negligence of its employees, agents or subcontractors; (ii) fraud or fraudulent misrepresentation; or (iii) any other liability that cannot be excluded as a matter of law.</p>
+
+    <p class="govuk-body">7.3 We provide the Service "as is" and on an "as available" basis only. We do not guarantee, warrant or promise the availability, accuracy, timeliness, completeness, quality, compatibility, security, performance, or fitness for a particular purpose of the Service or any of the content or data held within. Further, we do not guarantee, warrant or promise that the Service will be uninterrupted or error free. We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to time, we may restrict access to all or some parts of the Service.</p>
+
+    <p class="govuk-body">7.4 We take reasonable care to ensure that the information available through the Service is accurate and up to date. However, we accept no liability for the results of any action taken on the basis of the information it contains and all implied conditions, representations, warranties, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security, and accuracy are excluded from these Terms to the fullest extent that they may be excluded as a matter of law.</p>
+
+    <p class="govuk-body">7.5 The Service may contain links to other gov.uk sites. If the Service contains links to other sites and resources provided by third parties (for example, web links and resources outside of a gov.uk website), these links are provided for your information only. Such links should not be interpreted as approval by us of those linked websites or information You may obtain from them. We are not responsible and have no control over the contents of those sites or resources.</p>
+
+    <p class="govuk-body">7.6 Whilst we use reasonable endeavours to protect the Service from Destructive Features, we do not warrant that the Service is free from any Destructive Features and accept no liability for any delay or damage that may result from the transmission of any Destructive Features via the Service or via any files or data which are lost, corrupted or unavailable for You to download from the Service. You are responsible for implementing sufficient procedures and virus checks (including anti-virus and other malware and security checks) to satisfy your particular requirements for the accuracy of data input and output. We cannot accept any responsibility for any loss, disruption or damage to your files or data or your computer system which may arise out of or in connection with your use of the Service.</p>
+
+    <p class="govuk-body">7.7 Without prejudice to our other rights and remedies, we reserve the right to suspend or terminate your access to the Service without liability or prior notice.</p>
+
+    <h2 class ="govuk-heading-m">
+      8. Which laws apply to these Terms?
+    </h2>
+
+    <p class="govuk-body">8.1 These Terms, their subject matter and their formation (and any non-contractual disputes or claims) are governed by English law.</p>
+
+    <p class="govuk-body">8.2 We both agree to the exclusive jurisdiction of the courts of England and Wales will apply to these Terms.</p>
+
+    <h2 class ="govuk-heading-m">
+      9. Contact
+    </h2>
+
+    <p class="govuk-body">9.1 By registering to use the Service, You are giving DfE (via the TRA) permission to contact You or your organisation from time to time in relation to your access to and usage of the Service. We may review how you use the Service to ensure that any use by You is in accordance with these Terms.</p>
+
+    <p class="govuk-body">Please contact us if You have any queries regarding these Terms or your use of the Service via our contact details:</p>
+
+    <p class="govuk-body"><a class="govuk-link" mailto="teaching.status@education.gov.uk">Email: teaching.status@education.gov.uk</a></p>
+
+    <p class="govuk-body">Website: <a class="govuk-link" href="https://www.gov.uk/government/organisations/teaching-regulation-agency">https://www.gov.uk/government/organisations/teaching-regulation-agency</a></p>
+    <%= form_with url: terms_and_conditions_path, method: :patch do |f| %>
+      <%= f.govuk_submit "Accept" %>
+    <% end %>
+  </div>
+</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -8,6 +8,8 @@ shared:
     - uid
     - created_at
     - updated_at
+    - terms_and_conditions_version_accepted
+    - terms_and_conditions_accepted_at
   :dsi_user_sessions:
     - id
     - dsi_user_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   get "/auth/dfe/callback", to: "omniauth_callbacks#dfe"
   post "/auth/developer/callback", to: "omniauth_callbacks#dfe_bypass"
 
+  get "/terms-and-conditions", to: "terms_and_conditions#show"
+  patch "/terms-and-conditions" => "terms_and_conditions#update"
+
   scope "/feedback" do
     get "/", to: "feedbacks#new", as: :feedbacks
     post "/", to: "feedbacks#create"

--- a/db/migrate/20240711143411_add_terms_and_conditions_fields_to_dsi_user.rb
+++ b/db/migrate/20240711143411_add_terms_and_conditions_fields_to_dsi_user.rb
@@ -1,0 +1,8 @@
+class AddTermsAndConditionsFieldsToDsiUser < ActiveRecord::Migration[7.1]
+  def change
+    change_table :dsi_users, bulk: true do |f|
+      f.string :terms_and_conditions_version_accepted
+      f.datetime :terms_and_conditions_accepted_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_04_093302) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_11_143411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -49,6 +49,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_093302) do
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "terms_and_conditions_version_accepted"
+    t.datetime "terms_and_conditions_accepted_at"
     t.index ["email"], name: "index_dsi_users_on_email", unique: true
   end
 

--- a/spec/support/system/authentication_steps.rb
+++ b/spec/support/system/authentication_steps.rb
@@ -1,8 +1,9 @@
 module AuthenticationSteps
-  def when_i_sign_in_via_dsi(authorised: true, orgs: [organisation])
+  def when_i_sign_in_via_dsi(authorised: true, orgs: [organisation], accept_terms_and_conditions: true)
     given_dsi_auth_is_mocked(authorised:, orgs:)
     when_i_visit_the_sign_in_page
     and_click_the_dsi_sign_in_button
+    and_i_accept_the_terms_and_conditions(accept_terms_and_conditions)
   end
   alias_method :and_i_am_signed_in_via_dsi, :when_i_sign_in_via_dsi
 
@@ -10,6 +11,7 @@ module AuthenticationSteps
     given_dsi_auth_is_mocked(authorised: true, internal: true)
     when_i_visit_the_sign_in_page
     and_click_the_dsi_sign_in_button
+    and_i_accept_the_terms_and_conditions(true)
   end
   alias_method :and_i_am_signed_in_as_an_internal_user_via_dsi, :when_i_sign_in_as_an_internal_user_via_dsi
 
@@ -108,5 +110,11 @@ module AuthenticationSteps
       "name" => "Test School",
       "status" => { "id" => 1, "name" => status },
     }
+  end
+
+  def and_i_accept_the_terms_and_conditions(accept)
+    if accept
+      click_on "Accept"
+    end
   end
 end

--- a/spec/system/unauthorised_user_signs_in_spec.rb
+++ b/spec/system/unauthorised_user_signs_in_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "DSI authentication", type: :system do
 
   scenario "Unauthorised user signs in via DfE Sign In", test: :with_stubbed_auth do
     given_the_service_is_open
-    when_i_sign_in_via_dsi(authorised: false)
+    when_i_sign_in_via_dsi(authorised: false, accept_terms_and_conditions: false)
     then_i_am_not_authorised
   end
 

--- a/spec/system/user_accepts_terms_and_conditions.rb
+++ b/spec/system/user_accepts_terms_and_conditions.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Terms and conditions acceptance", type: :system do
+  include AuthenticationSteps
+
+  scenario "User accepts terms and conditions", test: :with_stubbed_auth do
+    given_the_service_is_open
+    when_i_sign_in_via_dsi(accept_terms_and_conditions: false)
+    then_i_am_signed_in
+    and_i_am_redirected_to_the_terms_and_conditions_page
+
+    when_i_sign_out
+    then_i_am_redirected_to_the_sign_in_page
+    when_i_sign_in_via_dsi(accept_terms_and_conditions: false)
+    then_i_am_redirected_to_the_terms_and_conditions_page
+
+    when_i_go_to_the_root
+    then_i_am_redirected_to_the_terms_and_conditions_page
+
+    when_i_click_accept
+    then_i_am_taken_to_the_root
+    and_i_see_the_successful_notification
+    and_the_dsi_user_has_been_updated
+
+    when_13_months_has_passed
+    when_i_go_to_the_root
+    when_i_sign_in_via_dsi(accept_terms_and_conditions: false)
+    then_i_am_redirected_to_the_terms_and_conditions_page
+    when_i_click_accept
+    then_i_am_taken_to_the_root
+    and_i_see_the_successful_notification
+  end
+
+  private
+
+  def then_i_am_signed_in
+    within("header") { expect(page).to have_content "Sign out" }
+    expect(DsiUser.count).to eq 1
+    expect(DsiUserSession.count).to eq 1
+  end
+
+  def and_i_am_redirected_to_the_terms_and_conditions_page
+    expect(page).to have_current_path("/terms-and-conditions")
+  end
+  alias_method(
+    :then_i_am_redirected_to_the_terms_and_conditions_page,
+    :and_i_am_redirected_to_the_terms_and_conditions_page,
+    )
+
+  def when_i_click_accept
+    click_on "Accept"
+  end
+
+  def then_i_am_taken_to_the_root
+    expect(page).to have_current_path("/search")
+  end
+
+  def and_i_see_the_successful_notification
+    expect(page).to have_content "Terms and conditions accepted"
+  end
+
+  def and_the_dsi_user_has_been_updated
+    expect(DsiUser.first.terms_and_conditions_version_accepted).to eq("1.0")
+    expect(DsiUser.first.terms_and_conditions_accepted_at).to_not be(nil)
+  end
+
+  def when_13_months_has_passed
+    travel_to 13.months.from_now
+  end
+
+  def when_i_go_to_the_root
+    visit root_path
+  end
+
+  def when_i_sign_out
+    click_on "Sign out"
+  end
+
+  def then_i_am_redirected_to_the_sign_in_page
+    expect(page).to have_current_path(sign_in_path)
+  end
+end

--- a/spec/system/user_belonging_to_closed_org_signs_in_spec.rb
+++ b/spec/system/user_belonging_to_closed_org_signs_in_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "DSI authentication", type: :system do
 
   scenario "User belonging to closed organisation signs in via DfE Sign In", test: :with_stubbed_auth do
     given_the_service_is_open
-    when_i_sign_in_via_dsi(orgs: [organisation(status: "Closed")])
+    when_i_sign_in_via_dsi(orgs: [organisation(status: "Closed")], accept_terms_and_conditions: false)
     then_i_am_not_authorised
   end
 


### PR DESCRIPTION
### Context
Introduce a system prompt for users to agree to the service's terms and conditions upon their first sign-in and at periodic intervals thereafter to ensure ongoing compliance and user understanding of the service policies. The T&C document is ready for implementation.

### Objectives:
Ensure Compliance: Guarantee that all users are aware of and agree to the terms and conditions governing the use of the service.

User Awareness: Enhance user understanding of service policies, including data use, privacy, and user responsibilities.

Periodic Acknowledgment: Require users to periodically review and agree to the terms and conditions to account for updates or changes.

###Link to Trello card

https://trello.com/c/qqRDCsbg/39-implement-terms-and-conditions-agreement-for-new-and-existing-users

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
