### PR TITLE
Allow unauthenticated user to view the terms and conditions page

### DIFF
--- a/app/controllers/terms_and_conditions_controller.rb
+++ b/app/controllers/terms_and_conditions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TermsAndConditionsController < ApplicationController
+  skip_before_action :authenticate_dsi_user!
+  skip_before_action :handle_expired_session!
   skip_before_action :enforce_terms_and_conditions_acceptance!
 
   def show

--- a/app/views/terms_and_conditions/show.html.erb
+++ b/app/views/terms_and_conditions/show.html.erb
@@ -204,8 +204,10 @@
     <p class="govuk-body"><a class="govuk-link" mailto="teaching.status@education.gov.uk">Email: teaching.status@education.gov.uk</a></p>
 
     <p class="govuk-body">Website: <a class="govuk-link" href="https://www.gov.uk/government/organisations/teaching-regulation-agency">https://www.gov.uk/government/organisations/teaching-regulation-agency</a></p>
-    <%= form_with url: terms_and_conditions_path, method: :patch do |f| %>
-      <%= f.govuk_submit "Accept" %>
+    <% if current_dsi_user %>
+      <%= form_with url: terms_and_conditions_path, method: :patch do |f| %>
+        <%= f.govuk_submit "Accept" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/spec/system/user_accepts_terms_and_conditions.rb
+++ b/spec/system/user_accepts_terms_and_conditions.rb
@@ -7,6 +7,11 @@ RSpec.describe "Terms and conditions acceptance", type: :system do
 
   scenario "User accepts terms and conditions", test: :with_stubbed_auth do
     given_the_service_is_open
+    when_i_visit_the_sign_in_page
+    and_i_click_on_terms_and_conditions_footer_link
+    then_i_am_redirected_to_the_terms_and_conditions_page
+    and_the_accept_button_is_hidden
+
     when_i_sign_in_via_dsi(accept_terms_and_conditions: false)
     then_i_am_signed_in
     and_i_am_redirected_to_the_terms_and_conditions_page
@@ -48,6 +53,14 @@ RSpec.describe "Terms and conditions acceptance", type: :system do
     :then_i_am_redirected_to_the_terms_and_conditions_page,
     :and_i_am_redirected_to_the_terms_and_conditions_page,
     )
+
+  def and_i_click_on_terms_and_conditions_footer_link
+    click_link "Terms and conditions"
+  end
+
+  def and_the_accept_button_is_hidden
+    expect(page).not_to have_link "Accept"
+  end
 
   def when_i_click_accept
     click_on "Accept"


### PR DESCRIPTION
### Context
As part of the terms and conditions flow it should be possible for an unauthenticated user to view the terms and conditions page. The accept button should be hidden in this case.

### Changes proposed in this pull request
Remove the need for authentication on the terms and conditions page. Hide the accept button in the case of no logged in user.

### Guidance to review
Can be checkedin the browser.

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
