### PR TITLE
Correct terms and condition language

### DIFF
--- a/app/views/terms_and_conditions/show.html.erb
+++ b/app/views/terms_and_conditions/show.html.erb
@@ -6,7 +6,7 @@
     <h1 class ="govuk-heading-m">
       1. Introduction
     </h1>
-    <p class="govuk-body">1.1 The Check a Teacher’s Record Service (as defined below) is a web service operated by the Department of Education (DfE). This web service is used by the Teaching Regulation Agency (TRA) as an executive agency to DfE to provide You with the Service (as also defined below).</p>
+    <p class="govuk-body">1.1 The Check the Children’s Barred List Service (as defined below) is a web service operated by the Department of Education (DfE) to provide You with the Service (as also defined below).</p>
 
     <p class="govuk-body">1.2 When referring to:</p>
     <ol type="a" class="govuk-body">
@@ -19,23 +19,19 @@
 
     <p class="govuk-body">1.4 By accessing and using the Service, You confirm that You accept and are bound by the Terms and have a valid basis for accessing and using the Service. If You do not agree to these Terms, You are not permitted to use this Service and You should not attempt to do so.</p>
 
-    <p class="govuk-body">1.5 These Terms refer to the following additional terms, which also apply to your use of the Service: </p>
+    <p class="govuk-body">1.5 These Terms refer to the following additional terms, which also apply to your use of the Service:</p>
     <ol type="a" class="govuk-body">
-      <li class="govuk-body">our privacy notice that details the processing of Personal Data through the Service (as may be amended by us from time to time);</li>
+      <li class="govuk-body">our <a class="govuk-link" href="https://teacherservices.education.gov.uk/Resources/Guidance/SelfServiceDataSharingGuidance.pdf">privacy notice</a> that details the processing of Personal Data through the Service (as may be amended by us from time to time);</li>
 
       <li class="govuk-body">any <a class="govuk-link" href="https://interactions.signin.education.gov.uk/terms">DfE Sign-In</a> terms and conditions that govern the access to the Service (as such terms of use may be amended by us from time to time).</li>
     </ol>
     <p class="govuk-body">1.6 Where there is a separate data sharing agreement, memorandum of understanding or any other agreement (as applicable) in place between DfE and your organisation, these Terms are mandatory and supplemental to the obligations set out in any such separate agreements or memorandum of understanding. Please note that these Terms include an Annex which contain additional obligations which will only apply where there is no separate data sharing provisions in place between DfE and your organisation. In the event of any conflict or inconsistency between these Terms and any separate data sharing agreement, memorandum of understanding or any other agreement between DfE and your organisation, these Terms shall prevail.</p>
 
-    <p class="govuk-body">1.7 The Service is a free service available for local authorities, schools, multi-academy trusts, accredited teacher training providers, other professional regulators, teacher supply agencies and other authorised organisations as permitted access by the DfE to view the record of any:</p>
-    <ol type="a" class="govuk-body">
-      <li class="govuk-body">trainee, newly qualified or fully qualified teacher holding early years teacher status or qualified teacher status – with the exception of teachers who have achieved qualified teacher status through holding qualified teacher learning and skills (QTLS);</li>
+    <p class="govuk-body">1.7 The Service is a free service available for schools, higher education institutions, multi-academy trusts and local authorities to make a childrens’ barred list check for any new employee who will be undertaking regulated activity. The list is usually checked as part of a new employee’s enhanced Disclosure and Barring Service (DBS) check. This service can be used to make a separate check if the new employee either:</p>
+    <ol class="govuk-body">
+      <li class="govuk-body">will start working with children while waiting for the result of an enhanced DBS check;</li>
 
-      <li class="govuk-body">teacher with an active restriction (including any teacher with QTLS to whom this applies);</li>
-
-      <li class="govuk-body">teacher who has been the subject of a decision by the Secretary of State for Education not to impose a prohibition order following a determination by a professional conduct panel of unacceptable professional conduct, conduct that may bring the teaching profession into disrepute or conviction of a relevant offence</li>
-
-      <li class="govuk-body">individual with a teacher reference number not included in the above.</li>
+      <li class="govuk-body">does not need an enhanced DBS check because they’ve worked with children in a school or college within the last 3 months.</li>
     </ol>
 
     <h2 class ="govuk-heading-m">
@@ -47,50 +43,45 @@
 
     <p class="govuk-body">Destructive Features: means any thing or device (including any software, code, file or programme) that may prevent, impair or otherwise adversely affect the operation of any computer software, hardware, network, programme or data including but not limited to computer viruses, worms, trojan horses or technologically harmful software.</p>
 
-    <p class="govuk-body">Check a Teacher’s Record: the web service through which access to the information regarding a teacher and the status of that individual is made available to certain third parties by DfE as more particularly described in Clauses 1.8 and 3.4(a), as DfE may update from time to time.</p>
+    <p class="govuk-body">Check the Children’s Barred List: the web service through which access to the Children’s Barred List is made available to authorised parties as more particularly described in Clauses 1.7 and 3.4(a), as DfE may update from time to time.</p>
 
     <p class="govuk-body">EU GDPR: the EU General Data Protection Regulation (Regulation (EU) 2016/679).</p>
 
     <p class="govuk-body">Personal Data: the personal data relating to an individual made available through the Service.</p>
 
+    <p class="govuk-body">Regulated Activity: The full legal definition of regulated activity is set out in Schedule 4 of the Safeguarding Vulnerable Groups Act 2006 as amended by the Protection of Freedoms Act 2012. HM Government has produced a Factual note on regulated activity in relation to children: scope1 and Keeping Children Safe in Education (KCSiE)2 guidance provides the following definition.</p>
+
+    <p class="govuk-body">Regulated activity includes:</p>
+
+    <ol type ="a" class="govuk-body">
+      <li class="govuk-body">teaching, training, instructing, caring for or supervising children if the person is unsupervised, or providing advice or guidance on physical, emotional or educational well-being, or driving a vehicle only for children;</li>
+
+      <li class="govuk-body">work for a limited range of establishments (known as ‘specified places’, which include schools and colleges), with the opportunity for contact with children, but not including work done by supervised volunteers.</li>
+    </ol>
+
+    <p class="govuk-body">Work under (a) or (b) is regulated activity only if done regularly. Some activities are always regulated activities, regardless of frequency or whether they are supervised or not.</p>
+
     <p class="govuk-body">Terms: means these terms and conditions that govern a user's access to and use of the Service.</p>
 
-    <p class="govuk-body">Service: means the Check a Teacher’s Record Web Service.</p>
+    <p class="govuk-body">Service: means the Check the Children’s Barred List Web Service.</p>
 
     <p class="govuk-body">UK GDPR: the EU GDPR as it forms part of the law of England and Wales, Scotland and Northern Ireland by virtue of section 3 of the European Union (Withdrawal) Act 2018.</p>
 
-    <p class="govuk-body">Valid Basis: an authorised reason to access use the Service to support your role in a) conducting safeguarding checks in line with Keeping Children Safe In Education or to comply with DfE funding requirements, b) verifying the qualified teacher status, early years teacher status, early years professional status, statutory induction status, mandatory qualification for teaching those with sensory impairments or a DfE national processional qualification, or c) an approved other use where you have written approval from DfE to use the servicethe statutory induction process.</p>
+    <p class="govuk-body">Valid Basis: a school, higher education institution, multi-academy trust and local authority undertaking children’s barred list checks in accordance with the Safeguarding of Vulnerable Groups Act 2006 and the Keeping Children Safe in Education (KCSiE) guidance.</p>
 
-    <p class="govuk-body">You, your and your organisation: means all directors, officers and employees of an organisation, that have approved access to the Service by DfE and are engaged in the performance of that organisation’s obligations to undertake statutory checks on teachers as required in legislation. </p>
+    <p class="govuk-body">You, your and your organisation: means all directors, officers and employees of an organisation, that have approved access to the Service by DfE and are engaged in the performance of that organisation’s obligations to undertake statutory checks on teachers as required in legislation.</p>
     <h2 class ="govuk-heading-m">
       3. Terms of Use
     </h2>
     <p class="govuk-body">3.1 These Terms must be complied with whenever You access the Service. You acknowledge that in addition to complying with these Terms, You must also comply with all applicable law, including Data Protection Legislation.</p>
 
-    <p class="govuk-body">3.2 In accessing the Service, You also acknowledge your organisation is an independent controller, as defined in Data Protection Legislation, with responsibility for ensuring:</p>
-    <ol type="a" class="govuk-body">
-      <li class="govuk-body">your use of data obtained from the Service complies with Data Protection Legislation; and</li>
+    <p class="govuk-body">3.2 In accessing the Service, You also acknowledge your organisation is an independent controller, as defined in Data Protection Legislation, with responsibility for ensuring that your use of data obtained from the Service complies with Data Protection Legislation and in accordance with these Terms.</p>
 
-      <li class="govuk-body">any processors required to access the Service on your organisation’s behalf do so with a valid basis for processing and always use any Personal Data obtained from the Service in compliance with Data Protection Legislation and in accordance with these Terms.</li>
-    </ol>
-    <p class="govuk-body">3.3 Without prejudice to Clause 3.2 and as set out in Clause 1.6, You will also need to comply with the Annex to these Terms in circumstances where your organisation does not have a separate data sharing agreement or memorandum of understanding (as applicable) in place with DfE.</p>
+    <p class="govuk-body">3.3 Without prejudice to Clause 3.2 and as set out in Clause 1.7, You will also need to comply with the Annex to these Terms in circumstances where your organisation does not have a separate data sharing agreement or memorandum of understanding (as applicable) in place with DfE.</p>
 
     <p class="govuk-body">3.4 As a user of this Service, You will at all times:</p>
     <ol type="a" class="govuk-body">
-      <li class="govuk-body">comply with the provisions of Data Protection Legislation in respect of all Personal Data, understanding that such Personal Data is provided to enable only authorised users from a registered organisation to carry out necessary checks on whether a trainee or teacher has:</li>
-      <li class="govuk-body">
-        <ol type="i" class="govuk-body">
-          <li class="govuk-body">achieved qualified teacher status, early years teacher status or early years professional status;</li>
-
-          <li class="govuk-body">completed their induction;</li>
-
-          <li class="govuk-body">been awarded a mandatory qualification for teachers of hearing impaired or visually impaired pupils;</li>
-
-          <li class="govuk-body">successfully completed a leadership or specialist national professional qualification;</li>
-
-          <li class="govuk-body">any teaching restrictions placed against them or has been the subject of a decision by the Secretary of State for Education not to impose a prohibition order following a determination by a professional conduct panel of unacceptable professional conduct or conduct that may bring the teaching profession into disrepute or the conviction of a relevant offence.</li>
-        </ol>
-      </li>
+      <li class="govuk-body">comply with the provisions of Data Protection Legislation in respect of all Personal Data, understanding that such Personal Data is provided to enable only authorised users from a registered organisation to carry out necessary checks on whether a new employee undertaking regulated activity has been barred from working with children.</li>
 
       <li class="govuk-body">not disclose any Personal Data from the Service to any unauthorised third party.</li>
 
@@ -108,7 +99,7 @@
 
       <li class="govuk-body">reserves the right to reset user passwords.</li>
 
-      <li class="govuk-body">owns all intellectual property rights (which is protected by Crown copyright) in and to the Service which includes any and all data (including Personal Data) or other information or material made available or published via the Service and these rights are licensed (not sold) to You. You have no intellectual property rights in relation to the foregoing other than the right to use them in accordance with these Terms.</li>
+      <li class="govuk-body">owns all intellectual property rights (which is protected by Crown copyright) in and to the Service which includes any and all data (including Personal Data) or other information or material made available or published via the Service and these rights are licensed (not sold) to You. You have no intellectual property rights in relation to the foregoing other than the right to use them in accordance with these Terms.</li>
     </ol>
     <p class="govuk-body">3.6 DfE may terminate these Terms and your (and your organisation's) access to and use of the Service at any time and for any reason by written notice with immediate effect.</p>
 
@@ -163,9 +154,10 @@
       <li class="govuk-body">any "robot", "bot", "spider", "scraper" or other automated device, program, tool, algorithm, code, process or methodology to access, obtain, copy, monitor or republish any portion of the Service or any content or services accessed via the same; or</li>
 
       <li class="govuk-body">any automated analytical technique aimed at analysing content in digital form to generate information which includes but is not limited to patterns, trends and correlations,</li>
-
-      <li class="govuk-body">the provisions in this Clause should be treated as an express reservation of our rights in this regard, including for the purposes of Article 4(3) of Digital Copyright Directive ((EU) 2019/790). This Clause shall not apply insofar as (but only to the extent that) we are unable to exclude or limit text or data mining or web scraping activity by contract under the laws which are applicable to us.</li>
     </ol>
+
+    <p class="govuk-body">the provisions in this Clause should be treated as an express reservation of our rights in this regard, including for the purposes of Article 4(3) of Digital Copyright Directive ((EU) 2019/790). This Clause shall not apply insofar as (but only to the extent that) we are unable to exclude or limit text or data mining or web scraping activity by contract under the laws which are applicable to us.</p>
+
     <p class="govuk-body">6.12 You must not violate or attempt to violate the security of the Service. You must not probe, scan or test the vulnerability of a system or network related to the Service. You must not misuse our Service by knowingly introducing Destructive Features. You must not attempt to gain unauthorised access or authentication to our Service (or any data held within it), the server on which our Service is stored, or any server, computer or database connected to our Service, through data mining, web scraping, hacking, spoofing, using another person’s password or by any other means. You must not attack our Service through a denial-of-service attack or a distributed denial-of service attack. Each of these acts is a criminal offence. We will report any such offence to the relevant law enforcement authorities and cooperate with them to determine your identity. In the event of such a breach your rights to use the Service will cease immediately.</p>
     <h2 class ="govuk-heading-m">
       7. Our Responsibilities and Liabilities
@@ -204,6 +196,7 @@
     <p class="govuk-body"><a class="govuk-link" mailto="teaching.status@education.gov.uk">Email: teaching.status@education.gov.uk</a></p>
 
     <p class="govuk-body">Website: <a class="govuk-link" href="https://www.gov.uk/government/organisations/teaching-regulation-agency">https://www.gov.uk/government/organisations/teaching-regulation-agency</a></p>
+
     <% if current_dsi_user %>
       <%= form_with url: terms_and_conditions_path, method: :patch do |f| %>
         <%= f.govuk_submit "Accept" %>


### PR DESCRIPTION
### Context

The incorrect terms and conditions language was merged. This PR brings the terms and conditions langauge to the correct state. 

### Changes proposed in this pull request

Update terms and conditions text. 

### Guidance to review

Open the content in a browser and look at the content. Compare with: https://educationgovuk.sharepoint.com/:w:/s/TeachingRegulationAgency791/EXfzqV5QiU9Gsg_FX1-hPFwBC2Q14DsnanF3SAleuCbZvQ?e=AJFBZy

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
