### PR TITLE
Update DfE Analytics to v1.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "omniauth_openid_connect"
 gem "omniauth-rails_csrf_protection"
 
 # Sending events to BigQuery
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.12.3"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.14.1"
 
 # Scheduling jobs
 gem "clockwork"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 80015465040513020d0c2b3a2ae45d4f05f3b547
-  tag: v1.12.3
+  revision: 79378cc466a40c6a6cba317e232cbf48ec79ab7d
+  tag: v1.14.1
   specs:
-    dfe-analytics (1.12.3)
+    dfe-analytics (1.14.1)
       google-cloud-bigquery (~> 1.38)
+      httparty (~> 0.21)
+      multi_xml (~> 0.6.0)
       request_store_rails (~> 2)
 
 GIT
@@ -99,8 +101,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     aes_key_wrap (1.1.0)
     ast (2.4.2)
     attr_required (1.0.1)
@@ -137,6 +139,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     cuprite (0.15)
       capybara (~> 3.0)
       ferrum (~> 0.14.0)
@@ -160,11 +163,12 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.11.0)
+      faraday-net_http (>= 2.0, < 3.4)
+      logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.1.0)
+    faraday-net_http (3.3.0)
       net-http
     ferrum (0.14)
       addressable (~> 2.5)
@@ -176,27 +180,28 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-apis-bigquery_v2 (0.67.0)
-      google-apis-core (>= 0.14.0, < 2.a)
-    google-apis-core (0.14.1)
+    google-apis-bigquery_v2 (0.77.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-core (0.15.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 1.9)
-      httpclient (>= 2.8.1, < 3.a)
+      httpclient (>= 2.8.3, < 3.a)
       mini_mime (~> 1.0)
+      mutex_m
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
-      rexml
-    google-cloud-bigquery (1.49.0)
+    google-cloud-bigquery (1.50.0)
+      bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.62)
+      google-apis-bigquery_v2 (~> 0.71)
       google-apis-core (~> 0.13)
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-cloud-core (1.7.0)
+    google-cloud-core (1.7.1)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (2.1.1)
+    google-cloud-env (2.2.0)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.4.0)
     googleauth (1.11.0)
@@ -226,6 +231,10 @@ GEM
     hashie (5.0.0)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -253,6 +262,7 @@ GEM
     launchy (3.0.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -265,7 +275,6 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
     minitest (5.25.1)
     msgpack (1.7.2)
     multi_json (1.15.0)
@@ -283,8 +292,9 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.16.7)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -341,7 +351,7 @@ GEM
       pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
-    public_suffix (5.0.5)
+    public_suffix (6.0.1)
     puma (6.4.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -416,7 +426,8 @@ GEM
     retriable (3.1.2)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.2.6)
+    rexml (3.3.6)
+      strscan
     rladr (1.2.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -523,6 +534,7 @@ GEM
       activesupport
       solargraph
     stringio (3.1.1)
+    strscan (3.1.0)
     swd (2.0.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -547,7 +559,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.5.0)
-    uri (0.13.0)
+    uri (0.13.1)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -582,7 +594,8 @@ GEM
     zeitwerk (2.6.17)
 
 PLATFORMS
-  ruby
+  arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   activerecord-session_store


### PR DESCRIPTION
The analytics library has a new version that includes improvements and
bugfixes. This brings the dependency up-to-date.