### PR TITLE
move pii fields to analytics_hidden_pii.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "omniauth_openid_connect"
 gem "omniauth-rails_csrf_protection"
 
 # Sending events to BigQuery
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.14.1"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.14.2"
 
 # Scheduling jobs
 gem "clockwork"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 79378cc466a40c6a6cba317e232cbf48ec79ab7d
-  tag: v1.14.1
+  revision: 706595e52fed211cee53ad99ceaeaabb47a059cc
+  tag: v1.14.2
   specs:
-    dfe-analytics (1.14.1)
+    dfe-analytics (1.14.2)
       google-cloud-bigquery (~> 1.38)
       httparty (~> 0.21)
       multi_xml (~> 0.6.0)
@@ -293,6 +293,8 @@ GEM
       net-protocol
     nio4r (2.7.0)
     nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
@@ -595,6 +597,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,0 +1,12 @@
+---
+shared:
+  :dsi_users:
+    - email
+    - first_name
+    - last_name
+    - uid
+  :feedbacks:
+    - email
+  :search_logs:
+    - last_name
+    - date_of_birth

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,12 +1,2 @@
 ---
-shared:
-  :dsi_users:
-    - email
-    - first_name
-    - last_name
-    - uid
-  :feedbacks:
-    - email
-  :search_logs:
-    - last_name
-    - date_of_birth
+shared: {}


### PR DESCRIPTION
### Context

Get an Identity service: does not use dfe-analytics but a rather older .NET package. It only contains web request data so there is no need for any hidden PII work
Check a Teacher's Record, Access your Teaching Qualifications and Check the Children's Barred List requires
dfe-analytics upgrade to version 1.14.2
copy analytics_pii.yml to analytics_hidden_pii.yml
clear analytics_pii.yml with an empty hash, after share:
raise PR / merge

###Changes proposed in this pull request
Move pii to a new analytics_hidden_pii file.


