### PR TITLE
Pin postgress version

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -13,7 +13,7 @@ module "postgres" {
   use_azure               = var.deploy_azure_backing_services
   azure_enable_monitoring = var.enable_monitoring
 #  azure_extensions        = ["PGCRYPTO","BTREE_GIST","CITEXT","PG_TRGM"]
-  server_version          = var.postgres_version
+  server_version          = "14"
   azure_sku_name          = var.postgres_flexible_server_sku
 
   azure_enable_high_availability = var.postgres_enable_high_availability


### PR DESCRIPTION
### Context
We need to update the postgres version to the latest stable one - however before this we need to make sure all services pin the postgres version so it’s not updated unexpectedly

### Changes proposed in this pull request
Set Postgres server version to 14


https://trello.com/c/4PBO6Miu/834-change-default-postgres-version-to-16

### Checklist

- [ ] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
