### PR TITLE
Configure preprod bigquery dataset name correctly

### DIFF
--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -155,7 +155,7 @@ locals {
     local.app_config,
     {
       BIGQUERY_PROJECT_ID = "teaching-qualifications",
-      BIGQUERY_DATASET    = "ccbl_events_${var.environment}",
+      BIGQUERY_DATASET    = var.environment == "preproduction" ? "ccbl_events_preprod" : "ccbl_events_${var.environment}",
       BIGQUERY_TABLE_NAME = "events",
       DB_SSLMODE = local.postgres_ssl_mode,
       HOSTING_ENVIRONMENT = var.environment,


### PR DESCRIPTION
### Context

BigQuery isn’t currently receiving data from preproduction check the children's barred list so it’s difficult to test things on there.

We’ve called the environment ‘preproduction’ but called the dataset ‘ccbl_events_preprod’. so this concatenation sets the env var incorrectly.

### Changes proposed in this pull request

Correctly assign dataset name cbbl_events_preprod when environment name == preproduction.


### Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/ROZTYjHn/341-cbl-preprod-bigquery-misconfigured)
### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
