### PR TITLE
Enable gcp wif in preproduction env

### DIFF
--- a/terraform/aks/config/preproduction.tfvars.json
+++ b/terraform/aks/config/preproduction.tfvars.json
@@ -20,5 +20,7 @@
     "preproduction.check-the-childrens-barred-list.education.gov.uk"
   ],
   "azure_enable_backup_storage": false,
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_dfe_analytics_federated_auth": true,
+  "gcp_dataset_name": "ccbl_events_preprod"
 }

--- a/terraform/aks/dfe_analytics.tf
+++ b/terraform/aks/dfe_analytics.tf
@@ -11,5 +11,5 @@ module "dfe_analytics" {
   namespace             = var.namespace
   service_short         = var.service_short
   environment           = local.app_name_suffix
-  gcp_dataset           = "ccbl_events_${var.config}"
+  gcp_dataset           = var.gcp_dataset_name != null ? var.gcp_dataset_name  : "ccbl_events_${var.config}"
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -147,6 +147,12 @@ variable "config" {
   description = "Long name of the environment configuration, e.g. development, staging, production..."
 }
 
+variable "gcp_dataset_name" {
+  description = "Name of the GCP dataset used by Bigquery for an environment. If null will use ccbl_events_{var.config} "
+  type    = string
+  default = null
+}
+
 locals {
   service_name = "check-childrens-barred-list"
   version      = "1.9.7"


### PR DESCRIPTION
### Context

Enable GCP WIF for the preproduction environment

### Changes proposed in this pull request

Add required config
Override gcp_dataset to point to existing preprod dataset

### Guidance to review

make preproduction terraform-plan

### Link to Trello card

https://trello.com/c/zBJkGucG/2142-ccbl-migrate-to-gcp-wif

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
