### PR TITLE
Add ingress rate limit

### DIFF
--- a/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
@@ -15,5 +15,16 @@
         }
       ]
     }
-  }
+  },
+  "rate_limit": [
+    {
+      "agent": "all",
+      "priority": 100,
+      "duration": 5,
+      "limit": 200,
+      "selector": "Host",
+      "operator": "GreaterThanOrEqual",
+      "match_values": "0"
+    }
+  ]
 }

--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -11,6 +11,7 @@ module "domains" {
   null_host_header      = true
   cached_paths          = try(each.value.cached_paths, [])
   redirect_rules        = try(each.value.redirect_rules, null)
+  rate_limit            = try(var.rate_limit, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/custom_domains/environment_domains/variables.tf
+++ b/terraform/custom_domains/environment_domains/variables.tf
@@ -2,3 +2,16 @@ variable hosted_zone {
   type = map(any)
   default = {}
 }
+
+variable "rate_limit" {
+  type = list(object({
+    agent        = optional(string)
+    priority     = optional(number)
+    duration     = optional(number)
+    limit        = optional(number)
+    selector     = optional(string)
+    operator     = optional(string)
+    match_values = optional(string)
+  }))
+  default = null
+}


### PR DESCRIPTION
### Context

Configure rate limiting for production

### Changes proposed in this pull request

Add global rate limit per IP for 5 minute intervals
Value for global rate set from checking ingress logs for the last 2 weeks and is higher than any 10 minute period in that time.

### Guidance to review

make production domains-plan

### Link to Trello card

https://trello.com/c/rmljcE5W/2345-add-rate-limiting-for-services

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
