### PR TITLE
Replace bobheadxi action with marocchino

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -103,15 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: review
     steps:
-      - name: Start review-${{ github.event.pull_request.number }} Deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          env: review-${{ github.event.pull_request.number }}
-          ref: ${{ github.head_ref }}
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -126,17 +117,19 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
           sha: ${{ needs.build.outputs.IMAGE_TAG }}
 
-      - name: Update review-${{ github.event.pull_request.number }} status
-        if: always()
-        uses: bobheadxi/deployments@v1
+      - name: Post sticky pull request comment
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          env: review-${{ github.event.pull_request.number }}
-          ref: ${{ github.head_ref }}
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ steps.deploy_review.outputs.deploy-url }}
+          header: review-app
+          message: |
+            ### Review App Deployed
+
+            | Environment | URL |
+            | --- | --- |
+            | review-${{ github.event.pull_request.number }} | ${{ steps.deploy_review.outputs.deploy-url }} |
+
+            The review app has been successfully deployed and is ready for testing.
 
   set_matrix:
     name: Set deployment matrix


### PR DESCRIPTION
Replace the bobheadxi/deployments GitHub Action with marocchino/sticky-pull-request-comment across review app workflows. This simplifies deployment notifications by using sticky PR comments instead of managing GitHub deployment records.

Changes:
- Remove bobheadxi/deployments start/finish deployment tracking
- Add sticky PR comments for deployment success notifications
- Add sticky PR comments for review app deletion notifications
- Preserve GitHub environment cleanup where it was implemented
- Add pull-requests: write permission where missing

### Context

<!-- Why are you making this change? -->

### Changes proposed in this pull request

<!-- Include a summary of the change. -->
<!-- Why this particular solution? -->
<!-- What assumptions have you made? -->
<!-- Are there any side effects to note? -->
<!-- If there are UI changes, please include Before and After screenshots. -->

### Guidance to review

<!-- How could someone else check this work? -->
<!-- Which parts do you want more feedback on? -->

### Link to Trello card

<!-- http://trello.com/123-example-card -->

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
