### PR TITLE
Add non-prod rate limiting

### DIFF
--- a/terraform/custom_domains/environment_domains/config/ccbl_preproduction.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_preproduction.tfvars.json
@@ -9,5 +9,6 @@
       "origin_hostname": "check-childrens-barred-list-preproduction.test.teacherservices.cloud",
       "cnames": {}
     }
-  }
+  },
+  "rate_limit_max": 150
 }

--- a/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_production.tfvars.json
@@ -16,15 +16,5 @@
       ]
     }
   },
-  "rate_limit": [
-    {
-      "agent": "all",
-      "priority": 100,
-      "duration": 5,
-      "limit": 200,
-      "selector": "Host",
-      "operator": "GreaterThanOrEqual",
-      "match_values": "0"
-    }
-  ]
+  "rate_limit_max": 200
 }

--- a/terraform/custom_domains/environment_domains/config/ccbl_test.tfvars.json
+++ b/terraform/custom_domains/environment_domains/config/ccbl_test.tfvars.json
@@ -9,5 +9,6 @@
       "origin_hostname": "check-childrens-barred-list-test.test.teacherservices.cloud",
       "cnames": {}
     }
-  }
+  },
+  "rate_limit_max": 150
 }

--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -12,6 +12,7 @@ module "domains" {
   cached_paths          = try(each.value.cached_paths, [])
   redirect_rules        = try(each.value.redirect_rules, null)
   rate_limit            = try(var.rate_limit, null)
+  rate_limit_max        = try(var.rate_limit_max, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/custom_domains/environment_domains/variables.tf
+++ b/terraform/custom_domains/environment_domains/variables.tf
@@ -15,3 +15,8 @@ variable "rate_limit" {
   }))
   default = null
 }
+
+variable "rate_limit_max" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
### Context

Add front door rate limiting for non prod envs

### Changes proposed in this pull request

Add rate limiting settings for test and preproduction
Update prod to the new variable format (but no change to the settings)

### Guidance to review

make env domains-plan

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
