### PR TITLE
Fix the resource group name in recover deleted postgres workflow

### DIFF
--- a/.github/workflows/restore-deleted-postgres.yml
+++ b/.github/workflows/restore-deleted-postgres.yml
@@ -52,7 +52,7 @@ jobs:
           source global_config/${{ inputs.environment }}.sh
           tf_vars_file=${TF_VARS_PATH}/${{ inputs.environment }}.tfvars.json
           echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
-          echo "RESOURCE_GROUP_NAME=${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
+          echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
 
           DELETED_DB_SERVER="${{ inputs.deleted-server }}"
           echo "DELETED_DB_SERVER=${DELETED_DB_SERVER}" >> $GITHUB_ENV


### PR DESCRIPTION
## Context
Reconfiguring the recover deleted postgres workflow

## Changes proposed in this pull request
Fix the resource group name in recover deleted postgres workflow

## Guidance to review
GitHub workflow use the recover deleted postgres github action to recover the deleted postgres server
https://github.com/DFE-Digital/github-actions/tree/master/restore-deleted-postgres
Workflow runs
https://github.com/DFE-Digital/check-childrens-barred-list/actions/runs/16808765871/job/47608250185
Recovered deleted postgres server
https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-ccbl-ts-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-ccbl-ts-pg-ptr-test/overview


## Link to Trello card
https://trello.com/c/QANXFMhR/2447-add-recover-deleted-postgres-workflow

## Checklist
- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [x]  Tested by running locally