### PR TITLE
Pin exact third party github action versions

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -68,7 +68,7 @@ runs:
         echo "deploy_url=$DEPLOY_URL" >> $GITHUB_OUTPUT
 
     - name: Use Terraform ${{ env.TERRAFORM_VERSION }}
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # Pinned at v2.0.3
       with:
         terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Post sticky pull request comment
         if: success()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
         with:
           header: review-app
           message: |
@@ -207,7 +207,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Slack channel on job failure
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
         env:
           SLACK_USERNAME: CI Deployment
           SLACK_TITLE: Deployment of check-the-childrens-barred-list ${{ env.REVIEW && 'review' }} failed

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -26,7 +26,7 @@ jobs:
           max-cache: true
 
       - name: Notify slack on failure
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at v2.3.3
         if: ${{ failure() }}
         env:
           SLACK_USERNAME: CI Deployment


### PR DESCRIPTION
### Context

Github action tags can be changed and pointed at new versions of a repo, this can lead to supply chain attacks and evidence of this occuring on other projects outside DfE exists.

Pinning to exact git hashes ensures that the version of the action cannot be changed without us explicitly changing it.

### Changes proposed in this pull request

- Pin untrusted third party github actions to exact git hashes.

### Guidance to review

- Check actions still run

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
