### PR TITLE
Add healthcheck for database table presence

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,8 +1,13 @@
+require_relative "../../lib/ok_computer_checks/database_integrity_check"
+
 OkComputer.mount_at = "healthcheck"
 
 OkComputer::Registry.register(
   "version",
   OkComputer::AppVersionCheck.new(env: "COMMIT_SHA"),
 )
+
+OkComputer::Registry.register "postgresql", OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register "database_integrity", OkComputerChecks::DatabaseIntegrityCheck.new
 
 OkComputer.make_optional(%w[version])

--- a/lib/ok_computer_checks/database_integrity_check.rb
+++ b/lib/ok_computer_checks/database_integrity_check.rb
@@ -1,0 +1,22 @@
+module OkComputerChecks
+  class DatabaseIntegrityCheck < OkComputer::ActiveRecordCheck
+    def check
+      if tables_missing_for_models?
+        mark_failure
+        mark_message "Database tables missing for some models"
+      else
+        mark_message "Database tables correctly loaded"
+      end
+    end
+
+    private
+
+    def tables_missing_for_models?
+      ActiveRecord::Base.descendants.map(&method(:table_present_for_model?)).include?(false)
+    end
+
+    def table_present_for_model?(model)
+      ActiveRecord::Base.connection.data_source_exists? model.table_name
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are running a disaster recovery test and need the healthcheck endpoint to quickly allow us to check that the database is correctly loaded.

### Changes proposed in this pull request

- Adds a healthcheck to /health/all that checks if all database tables are correctly loaded.

### Guidance to review

- Load a review app
- Visit /health/all
- Verify that the database integrity check correctly passes
