### PR TITLE
Fix flaky search-log system specs

### DIFF
--- a/spec/system/user_searches_with_matching_record_spec.rb
+++ b/spec/system/user_searches_with_matching_record_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe "Valid search", type: :system do
   end
 
   def then_i_see_a_result
-    expect(page).to have_content("Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}", wait: 10)
-    expect(page).to have_content "Possible match with the children’s barred list"
+    expect(page).to have_content("Possible match with the children’s barred list", wait: 10)
+    expect(page).to have_content("Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}")
     expect(page).to have_content @record.last_name
     expect(page).to have_content Date.parse(@record.date_of_birth).to_fs(:long_uk)
   end

--- a/spec/system/user_searches_with_no_matching_record_spec.rb
+++ b/spec/system/user_searches_with_no_matching_record_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "No matching record search", type: :system do
     and_i_search_for_a_different_last_name
     and_i_enter_their_date_of_birth
     and_i_click_search
-    and_my_search_is_logged
     then_i_see_the_no_record_page
+    and_my_search_is_logged
     and_event_tracking_is_working
   end
 
@@ -46,8 +46,8 @@ RSpec.describe "No matching record search", type: :system do
   end
 
   def then_i_see_the_no_record_page
-    expect(page).to have_content("Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}", wait: 10)
-    expect(page).to have_content "No record found"
+    expect(page).to have_content("No record found", wait: 10)
+    expect(page).to have_content("Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}")
     expect(page).to have_content(
       "No record found for Random name born on #{Date.parse(@record.date_of_birth).to_fs(:long_uk)}")
   end

--- a/spec/system/user_searches_with_stringified_month_record_spec.rb
+++ b/spec/system/user_searches_with_stringified_month_record_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe "Valid search", type: :system do
   end
 
   def then_i_see_a_result
-    expect(page).to have_content("Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}", wait: 10)
-    expect(page).to have_content "Possible match with the children’s barred list"
+    expect(page).to have_content("Possible match with the children’s barred list", wait: 10)
+    expect(page).to have_content("Searched at #{SearchLog.last.created_at.to_fs(:time_on_date_long)}")
     expect(page).to have_content @record.last_name
     expect(page).to have_content Date.parse(@record.date_of_birth).to_fs(:long_uk)
   end


### PR DESCRIPTION
### Context

Three search system specs failed consistently with `NoMethodError` on `SearchLog.last` (nil), slowing down every test run:

- `user_searches_with_matching_record_spec.rb`
- `user_searches_with_stringified_month_record_spec.rb`
- `user_searches_with_no_matching_record_spec.rb`

### Changes proposed in this pull request

This is a test bug, not an app bug. The app works: the controller creates the `SearchLog` and the view renders its `created_at` (a failure screenshot showed a fully-rendered result page including "Searched at …").

The specs built their expected string by evaluating `SearchLog.last.created_at` **eagerly**, the instant after `click_button "Search"`. Under the cuprite async driver the request hasn't completed yet, so the row doesn't exist and the interpolation raises. The `wait: 10` sat on `have_content`, which only retries the page-content match — not the eager `SearchLog.last` lookup that already blew up.

The fix is test-only: each `wait` is now anchored on page content that doesn't touch the database (the result / no-record heading), and `SearchLog.last` is read only afterwards — by which point the request has finished and the row is committed on the shared connection. In the no-match spec, `and_my_search_is_logged` also moved to run after the page assertion.

No application code changes.

### Guidance to review

- Run the three specs (and the full suite) locally and confirm they pass — they now sit at 0 failures where they previously failed.
- Sanity-check the reordering: in each spec a non-`SearchLog` content assertion now precedes any `SearchLog.last` dereference.

### Link to Trello card

No Trello card — test fix found while working on #579.

### Checklist

- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)