### PR TITLE
Update PR template to reference GitHub issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,13 +15,13 @@
 <!-- How could someone else check this work? -->
 <!-- Which parts do you want more feedback on? -->
 
-### Link to Trello card
+### Link to GitHub issue
 
-<!-- http://trello.com/123-example-card -->
+<!-- https://github.com/DFE-Digital/check-childrens-barred-list/issues/123 -->
 
 ### Checklist
 
-- [ ] Attach to Trello card
+- [ ] Linked to GitHub issue
 - [ ] Rebased main
 - [ ] Cleaned commit history
 - [ ] Tested by running locally


### PR DESCRIPTION
### Context

The project now tracks tickets in GitHub rather than Trello, so the pull request template should point contributors to GitHub issues.

### Changes proposed in this pull request

- Renamed the "Link to Trello card" section to "Link to GitHub issue" with an example issue URL.
- Updated the checklist item from "Attach to Trello card" to "Linked to GitHub issue".

### Guidance to review

Check `.github/pull_request_template.md` renders as expected — this PR's own description uses the existing (old) template since it was created before the change landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)