### PR TITLE
Add manual deploy workflow

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,43 @@
+name: Manual Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to deploy to
+        required: true
+        type: choice
+        default: test
+        options:
+          - test
+          - preproduction
+          - production
+      image_tag:
+        description: Image tag to deploy
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: ${{ github.event.inputs.environment }} deployment
+    runs-on: ubuntu-latest
+    concurrency: deploy_${{ github.event.inputs.environment }}
+    environment:
+      name: ${{ github.event.inputs.environment }}
+      url: ${{ steps.deploy_app.outputs.deploy-url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Deploy App to ${{ github.event.inputs.environment }}
+        id: deploy_app
+        uses: ./.github/actions/deploy/
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          environment: ${{ github.event.inputs.environment }}
+          sha: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
### Context

Releases currently happen automatically on push to `main` and via review apps on labelled PRs. There's no way to deploy a specific, already-built image to an environment on demand — needed for re-deploying a known-good build, deploying a branch build to `test` for manual verification, or promoting a particular image to `preproduction`/`production` outside the push pipeline.

### Changes proposed in this pull request

Adds a `workflow_dispatch` workflow (`.github/workflows/manual-deploy.yml`) that deploys a chosen image tag to a selected environment on demand:

- Inputs: `environment` (choice of `test` / `preproduction` / `production`, default `test`) and `image_tag` (the image to deploy, which must already exist in the registry).
- Reuses the existing `./.github/actions/deploy` composite action, passing the image tag through as `sha`.
- Uses the `deploy_<environment>` concurrency group, the same one the automated `build-and-deploy` pipeline uses, so manual runs serialise against automated deployments to the same environment (no concurrent Terraform applies).
- Runs under the target GitHub Environment, so existing environment protection rules (e.g. required reviewers on `production`) gate manual deploys.

No application code changes.

### Guidance to review

- Trigger via **Actions → Manual Deploy → Run workflow**, choosing an environment and supplying an image tag that already exists in `ghcr.io/dfe-digital/check-childrens-barred-list` (e.g. the `IMAGE_TAG`/SHA from a prior `build-and-deploy` run).
- Confirm the run picks up the correct environment secrets/protection rules and that the deploy completes.

### Link to GitHub issue

N/A

### Checklist

- [x] Rebased main
- [x] Cleaned commit history