### PR TITLE
Upgrade GOV.UK Design System to v6 (govuk-frontend 6.3.0 + govuk-components 6.4.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     attr_required (1.0.1)
     backport (1.2.0)
     base64 (0.3.0)
-    benchmark (0.4.1)
+    benchmark (0.5.0)
     bigdecimal (3.3.1)
     bindata (2.4.15)
     bindex (0.8.1)
@@ -127,8 +127,8 @@ GEM
       activesupport
       tzinfo
     coderay (1.1.3)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.4)
+    concurrent-ruby (1.3.7)
+    connection_pool (2.5.5)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -213,10 +213,10 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (5.11.3)
+    govuk-components (6.4.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
-      view_component (>= 4.0, < 4.1)
+      view_component (>= 4.9, < 4.13)
     govuk_design_system_formbuilder (5.11.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -237,7 +237,7 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.7)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
     irb (1.15.2)
@@ -278,7 +278,7 @@ GEM
     matrix (0.4.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    minitest (5.26.0)
+    minitest (5.27.0)
     msgpack (1.8.3)
     multi_json (1.17.0)
     multi_xml (0.6.0)
@@ -584,8 +584,9 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     version_gem (1.1.3)
-    view_component (4.0.2)
-      activesupport (>= 7.1.0, < 8.1)
+    view_component (4.12.0)
+      actionview (>= 7.1.0)
+      activesupport (>= 7.1.0)
       concurrent-ruby (~> 1)
     web-console (4.2.1)
       actionview (>= 6.0.0)

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -4,7 +4,7 @@ $govuk-assets-path: "/";
 $govuk-fonts-path: "/";
 $govuk-images-path: "/";
 
-@import "govuk-frontend/dist/govuk/all";
+@import "govuk-frontend/dist/govuk/index";
 
 // `govuk_service_navigation` only renders links, but sign out is
 // state-changing and must be a POST. `button_to` renders a <button> inside a

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": "true",
   "dependencies": {
     "esbuild": "^0.28.1",
-    "govuk-frontend": "^5.6.0",
+    "govuk-frontend": "^6.3.0",
     "sass": "^1.99.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,10 +284,10 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-govuk-frontend@^5.6.0:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.13.0.tgz#11126d32a9ef0db17b19276253746da1ade4338b"
-  integrity sha512-6N3pHelWN7wftdM6e4YEzZAfattapa1gnd+Al6d5PUbfTr9D+T2dnphpNpjX75CTEhihlQqlL0RDQ3WIfZ3PSg==
+govuk-frontend@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-6.3.0.tgz#1ff97c181ab08ec0b96fdb96628066a5d32e1018"
+  integrity sha512-cXIQxm5PHCsbic47GXZrVBZhAeeshTLRL6ZBKilLsR6rMCjJuWb7Fruq0VUNMBJFlJk/srsRj/q8d5bM9cgKoA==
 
 immutable@^5.1.5:
   version "5.1.5"


### PR DESCRIPTION
### Context

Two open Dependabot PRs bump the GOV.UK Design System to v6, and they are a lockstep pair that must land together:

- #584 — govuk-frontend (npm, CSS/JS) 5.13.0 → 6.3.0 (was failing Build + Rspec)
- #569 — govuk-components (gem, Ruby HTML) 5.11.3 → 6.4.0 (Gemfile.lock conflict, stale)

govuk-components 6.4.0 renders v6 header/footer markup that only matches v6 CSS classes. No spec covers that markup, so merging either PR alone would put a visually-broken, CI-green state on `main`. This PR combines both bumps and supersedes #584 and #569.

### Changes proposed in this pull request

- Bump `govuk-frontend` to `^6.3.0` (`package.json` + `yarn.lock`).
- **Fix the #584 build failure:** v6 removed `govuk-frontend/dist/govuk/all.scss`, which `app/assets/stylesheets/main.scss` imported, aborting `yarn build:css`. Repointed the import at the surviving `dist/govuk/index` entry (kept the config-vars-then-`@import` pattern rather than a wider `@use` rewrite).
- Bump `govuk-components` to `6.4.0`, regenerating `Gemfile.lock` cleanly against current `main` (resolves #569's stale conflict). This pulls `view_component` to 4.12.0 (its `>= 4.9, < 4.13` constraint); no other gem pins `view_component`.

The layout was already migrated to the v6 header API (`govuk_header` with no args, `govuk_service_navigation`, `govuk-template--rebranded`), so no template changes were needed.

### Guidance to review

Local verification all green: `yarn build:css`, `yarn build`, `bin/rails spec` (119 examples, 0 failures), `rubocop`, `prettier`.

Because no spec covers header/footer markup, the real check is visual — a review app is deploying via the `deploy` label. Please confirm on it: header + rebrand crown, service navigation (service name, sign in/out, internal-user items), footer "Get help" block and inline links, phase banner, back link, and forms.

### Link to GitHub issue

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/360

### Checklist

- [x] Linked to GitHub issue
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally